### PR TITLE
fix: support custom signals

### DIFF
--- a/src/stores/index.js
+++ b/src/stores/index.js
@@ -23,7 +23,7 @@ const urlParams = new URLSearchParams(queryString);
 export const sensors = readable(sensorList, (set) => {
   const sensorsOption = urlParams.get('sensors');
   if (sensorsOption) {
-    set(withSensorEntryKey(JSON.parse(decodeURIComponent(sensorsOption))));
+    set(JSON.parse(decodeURIComponent(sensorsOption)).map(withSensorEntryKey));
   }
 });
 


### PR DESCRIPTION
closes #301 

e.g. 

[link](https://deploy-preview-302--cmu-delphi-covidcast.netlify.app/?sensors=%5B%7B%22name%22%3A%22Search%20Trends%20(Google)%22%2C%22id%22%3A%22ght%22%2C%22tooltipText%22%3A%22Relative%20frequency%20of%20COVID-related%20Google%20searches%22%2C%22mapTitleText%22%3A%22Relative%20frequency%20of%20COVID-related%20Google%20searches%22%2C%22chartTitleText%22%3A%22Relative%20frequency%20of%20COVID-related%20Google%20searches%22%2C%22yAxis%22%3A%22Frequency%20(arbitrary%20scale)%22%2C%22format%22%3A%22raw%22%2C%22signal%22%3A%22raw_search%22%2C%22levels%22%3A%5B%22msa%22%2C%22state%22%5D%2C%22type%22%3A%22public%22%7D%5D)