### PR TITLE
Fixed glitches on the legend when switching between signals

### DIFF
--- a/src/components/Legend.svelte
+++ b/src/components/Legend.svelte
@@ -374,6 +374,43 @@
     stroke-width: 2px;
     stroke-linecap: round;
   }
+
+  .loader-container {
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin-bottom: 0.5rem;
+  }
+
+  .loader {
+    border: 4px solid #f3f3f3;
+    border-radius: 50%;
+    border-top: 4px solid #c41230;
+    width: 20px;
+    height: 20px;
+    -webkit-animation: spin 1s linear infinite; /* Safari */
+    animation: spin 1s linear infinite;
+  }
+
+  /* Safari */
+  @-webkit-keyframes spin {
+    0% {
+      -webkit-transform: rotate(0deg);
+    }
+    100% {
+      -webkit-transform: rotate(360deg);
+    }
+  }
+
+  @keyframes spin {
+    0% {
+      transform: rotate(0deg);
+    }
+    100% {
+      transform: rotate(360deg);
+    }
+  }
 </style>
 
 <div aria-label="legend" class="legend {$signalType === 'value' ? 'value' : ''}">
@@ -410,7 +447,11 @@
       </div>
     </div>
   </div>
-  {#if $signalType === 'direction'}
+  {#if !$currentDataReadyOnMap}
+    <div class="loader-container">
+      <div class="loader" />
+    </div>
+  {:else if $signalType === 'direction'}
     <div class="trend-legend-grouping">
       <ul class="legend-labels">
         <li>


### PR DESCRIPTION
Display a "loading" ring on the legend when the map is being updated.

This will fix the following issues:
- The color ramp/bubbles/spikes on the legend become gray when data is being loaded.
- Bubbles/spikes suddenly become too big.

To reproduce the second issue, 
1) Set to "Cases per 100,000 people", July 31, and bubbles.
2) Delete cache (e.g., using DevTools) and refresh.
3) Change to "Cases".


