### PR TITLE
feat: add background to map title for visibility

### DIFF
--- a/src/components/MapOverlays.svelte
+++ b/src/components/MapOverlays.svelte
@@ -46,7 +46,6 @@
   /** desktop **/
   @media only screen and (min-width: 767px) {
     .title-container {
-      background-color: unset;
       box-shadow: none;
     }
   }

--- a/src/components/MapOverlays.svelte
+++ b/src/components/MapOverlays.svelte
@@ -38,7 +38,7 @@
     display: flex;
     align-items: flex-start;
     justify-content: center;
-    margin-top: 2px;
+    margin: 2px 5px;
   }
   .signal-description {
     margin-bottom: 0.25em;

--- a/src/components/MapOverlays.svelte
+++ b/src/components/MapOverlays.svelte
@@ -49,8 +49,6 @@
     .title-container {
       box-shadow: none;
       border: none;
-      border-radius: 0;
-      margin-top: 0;
     }
   }
 

--- a/src/components/MapOverlays.svelte
+++ b/src/components/MapOverlays.svelte
@@ -38,6 +38,7 @@
     display: flex;
     align-items: flex-start;
     justify-content: center;
+    margin-top: 2px;
   }
   .signal-description {
     margin-bottom: 0.25em;
@@ -47,6 +48,9 @@
   @media only screen and (min-width: 767px) {
     .title-container {
       box-shadow: none;
+      border: none;
+      border-radius: 0;
+      margin-top: 0;
     }
   }
 

--- a/src/components/MapOverlays.svelte
+++ b/src/components/MapOverlays.svelte
@@ -68,7 +68,7 @@
 </style>
 
 <div class="map-top-overlay">
-  <div class="title-container">
+  <div class="title-container container-bg">
     <Title {showDate} />
   </div>
   <div class="map-controls-container">

--- a/src/modes/overview/OverviewWrapper.svelte
+++ b/src/modes/overview/OverviewWrapper.svelte
@@ -250,9 +250,6 @@
         'search view'
         'map map';
     }
-    .root > :global(.search-container) {
-      margin: 0 0 0 6px;
-    }
 
     .mobileHide {
       display: none !important;


### PR DESCRIPTION
closes #512 

**Prerequisites**:

- [x] Unless it is a hotfix it should be merged against the `dev` branch
- [x] Branch is up-to-date with the branch to be merged with, i.e. `dev`
- [x] Build is successful
- [x] Code is cleaned up and formatted

### Summary
I created this pull request mainly to remind myself of how the git process works and get familiar with the codebase. If this is not the way you would like to fix this issue totally fine to just reject this.

Adding background class to map title.
Tweaking desktop @media rule so that the map title has a background, rounded on mobile, flat no edges on desktop. 

DESKTOP
Before
<img width="687" alt="Screen Shot 2020-09-30 at 10 26 15 AM" src="https://user-images.githubusercontent.com/14190352/94702479-d059c600-030b-11eb-8b9a-34d6aa364a71.png">

After
<img width="983" alt="Screen Shot 2020-09-30 at 10 57 34 AM" src="https://user-images.githubusercontent.com/14190352/94702786-26c70480-030c-11eb-8668-77c46b1c1cc0.png">


MOBILE
Before
<img width="424" alt="Screen Shot 2020-09-30 at 11 00 13 AM" src="https://user-images.githubusercontent.com/14190352/94702840-37777a80-030c-11eb-977f-eb5569eddbc6.png">

After
<img width="419" alt="Screen Shot 2020-09-30 at 11 16 55 AM" src="https://user-images.githubusercontent.com/14190352/94704961-7d354280-030e-11eb-85d9-1efc71f7bc7a.png">



