### PR TITLE
Switch to claims-only version of the hospital-admissions signal

### DIFF
--- a/src/stores/constants.js
+++ b/src/stores/constants.js
@@ -406,7 +406,7 @@ const defaultSensors = [
     name: 'COVID Hospital Admissions',
     longDescription:
       // prettier-ignore
-      `Delphi receives from our health system partners aggregated statistics on COVID-related hospital admissions, derived from ICD codes found in insurance claims and other medical records. Using this data, we estimate the percentage of new hospital admissions each day that are related to COVID-19. Note that these estimates are based only on admissions by patients whose data is accessible to our partners, and address new hospital admissions each day, not all currently hospitalized patients who have COVID-related diagnoses.`,
+      `Delphi receives from our health system partners aggregated statistics on COVID-related hospital admissions, derived from ICD codes found in insurance claims. Using this data, we estimate the percentage of new hospital admissions each day that are related to COVID-19. Note that these estimates are based only on admissions by patients whose data is accessible to our partners, and address new hospital admissions each day, not all currently hospitalized patients who have COVID-related diagnoses.`,
     links: [
       {
         alt: 'Technical description',
@@ -414,7 +414,7 @@ const defaultSensors = [
       },
     ],
     id: 'hospital-admissions',
-    signal: 'smoothed_adj_covid19',
+    signal: 'smoothed_adj_covid19_from_claims',
     levels: ['county', 'msa', 'state'],
     mapTitleText:
       // prettier-ignore


### PR DESCRIPTION
**Prerequisites**:

- [x] Unless it is a hotfix it should be merged against the `dev` branch
- [x] Branch is up-to-date with the branch to be merged with, i.e. `dev`
- [ ] Build is successful
- [x] Code is cleaned up and formatted

### Summary

The original `hospital-admissions:smoothed_adj_covid19` signal becomes defunct 1 October. The replacement signal is `hospital-admissions:smoothed_adj_covid19_from_claims. The new signal was approved late afternoon 1 October and will become available in metadata early morning on 2 October.

- [x] @RoniRos to double-check that the language change should involve only removing the phrase "and other medical records"
- [x] viz review
- [ ] merge, build the release, and upload to CMS