### PR TITLE
coverage info

### DIFF
--- a/src/components/MapOverlays.svelte
+++ b/src/components/MapOverlays.svelte
@@ -7,12 +7,14 @@
   import ColorLegend from './legends/ColorLegend.svelte';
   import BubbleLegend from './legends/BubbleLegend.svelte';
   import SpikeLegend from './legends/SpikeLegend.svelte';
+  import MapSummary from './MapSummary.svelte';
 
   export let map = null;
   export let mapLoading = true;
   export let legendLoading = true;
   export let zoom = 1.0;
   export let showDate = false;
+  export let summary = null;
 </script>
 
 <style>
@@ -66,6 +68,14 @@
   .legend-container > :global(.encoding-wrapper) {
     margin-bottom: 6px;
   }
+
+  .summary-container {
+    position: absolute;
+    margin: 0.25em;
+    right: 0;
+    bottom: 0;
+    z-index: 1000;
+  }
 </style>
 
 <div class="map-top-overlay">
@@ -91,4 +101,7 @@
       <SpikeLegend loading={legendLoading} {zoom} />
     {/if}
   </div>
+</div>
+<div class="summary-container" aria-label="map data summary">
+  <MapSummary {summary} />
 </div>

--- a/src/components/MapSummary.svelte
+++ b/src/components/MapSummary.svelte
@@ -1,0 +1,51 @@
+<script>
+  import { getLevelInfo } from '../stores/constants';
+
+  export let summary = null;
+
+  $: total = summary ? summary.items.reduce((acc, d) => acc + (d.level === summary.level ? 1 : 0), 0) : 0;
+
+  $: info = getLevelInfo(summary ? summary.level : 'county');
+
+  let loading = true;
+  let valid = 0;
+  $: {
+    loading = true;
+    if (summary && summary.data) {
+      summary.data.then((rows) => {
+        let validRows = 0;
+        for (const row of rows) {
+          if (row.geo_value.endsWith('000') || row.value == null || Number.isNaN(row.value)) {
+            // mega county ignore or invalid
+            continue;
+          }
+          validRows++;
+        }
+        loading = false;
+        // update once for better performance
+        valid = validRows;
+      });
+    }
+  }
+
+  function percent(v) {
+    return Math.round((v * 100) / total);
+  }
+</script>
+
+<style>
+  .root {
+    font-size: 0.7rem;
+  }
+  .hidden {
+    display: none;
+  }
+</style>
+
+<div
+  class="root base-font-size container-style"
+  class:hidden={!summary || !summary.data}
+  class:loading-bg={loading}
+  title={`Showing data for ${valid} ${info.labelPlural} out of ${total} ${info.labelPlural} (${percent(valid)}%)`}>
+  {percent(valid)}% Coverage
+</div>

--- a/src/modes/overview/OverviewWrapper.svelte
+++ b/src/modes/overview/OverviewWrapper.svelte
@@ -282,7 +282,12 @@
   {/if}
 
   <div class="map-container" class:mobileHide={!mobileShowMap} class:pick={pickMapMode}>
-    <MapOverlays {map} mapLoading={loading} legendLoading={loading} {zoom} />
+    <MapOverlays
+      {map}
+      mapLoading={loading}
+      legendLoading={loading}
+      {zoom}
+      summary={{ data, level: $currentLevel, items: regionSearchList }} />
     <MapBox
       bind:this={map}
       on:loading={(e) => (loading = e.detail)}


### PR DESCRIPTION
based on #540 for simpler development

closes #538 

**Prerequisites**:

- [x] Unless it is a hotfix it should be merged against the `dev` branch
- [x] Branch is up-to-date with the branch to be merged with, i.e. `dev`
- [x] Build is successful
- [x] Code is cleaned up and formatted

### Summary

adds a small field to the bottom right of the map showing the "coverage":

![image](https://user-images.githubusercontent.com/4129778/95318531-fb599200-0896-11eb-8707-d16df2bda311.png)

a tooltip explains it:

![image](https://user-images.githubusercontent.com/4129778/95318596-13c9ac80-0897-11eb-97cf-ebd05dc1961c.png)

coverage is the percentage of valid level (e.g., county) data for the current signal and date. For example in the given screenshot it shows that the map has only 'Doctor Visits' data for 61% of all counties. Mega Counties are explicitly excluded. 

In the issue I suggested more value but I think the coverage is the most important one
