### PR TITLE
improve vega highlight performance

### DIFF
--- a/src/components/DetailView/vegaSpec.js
+++ b/src/components/DetailView/vegaSpec.js
@@ -70,7 +70,7 @@ export const xDateEncoding = {
   axis: {
     title: null,
     format: '%m/%d',
-    formatType: 'time',
+    formatType: 'cachedTime',
     tickCount: 'day',
     grid: false,
   },
@@ -253,6 +253,7 @@ export function createSpec(sensor, primaryValue, selections, initialSelection) {
       },
     ],
     config: {
+      customFormatTypes: true,
       legend: {
         disable: true,
       },

--- a/src/components/DetailView/vegaSpec.js
+++ b/src/components/DetailView/vegaSpec.js
@@ -13,7 +13,10 @@ export const CURRENT_DATE_HIGHLIGHT = {
       as: 'date_value',
     },
   ],
-  mark: 'rule',
+  mark: {
+    type: 'rule',
+    tooltip: false,
+  },
   encoding: {
     color: {
       value: '#c00',

--- a/src/components/Vega.svelte
+++ b/src/components/Vega.svelte
@@ -1,9 +1,12 @@
 <script>
   import { onMount, onDestroy, createEventDispatcher } from 'svelte';
   import embed from 'vega-embed';
-  import { Error } from 'vega';
+  import { Error, expressionFunction } from 'vega';
   import { observeResize, unobserveResize } from '../util';
   import { createVegaTooltipAdapter } from './tooltipUtils';
+  import { cachedTime } from './customVegaFunctions';
+
+  expressionFunction('cachedTime', cachedTime);
 
   export let data = Promise.resolve([]);
 

--- a/src/components/Vega.svelte
+++ b/src/components/Vega.svelte
@@ -177,17 +177,17 @@
       root.setAttribute('role', 'figure');
       signalListeners.forEach((signal) => {
         r.view.addSignalListener(signal, (name, value) => {
-          dispatch('signal', { name, value, view: r.view });
+          dispatch('signal', { name, value, view: r.view, spec });
         });
       });
       dataListeners.forEach((data) => {
         r.view.addDataListener(data, (name, value) => {
-          dispatch('dataListener', { name, value, view: r.view });
+          dispatch('dataListener', { name, value, view: r.view, spec });
         });
       });
       eventListeners.forEach((type) => {
         r.view.addEventListener(type, (event, item) => {
-          dispatch(type, { event, item, view: r.view });
+          dispatch(type, { event, item, view: r.view, spec });
         });
       });
       updateData(vegaPromise, data);

--- a/src/components/Vega.svelte
+++ b/src/components/Vega.svelte
@@ -4,9 +4,10 @@
   import { Error, expressionFunction } from 'vega';
   import { observeResize, unobserveResize } from '../util';
   import { createVegaTooltipAdapter } from './tooltipUtils';
-  import { cachedTime } from './customVegaFunctions';
+  import { cachedTime, cachedNumber } from './customVegaFunctions';
 
   expressionFunction('cachedTime', cachedTime);
+  expressionFunction('cachedNumber', cachedNumber);
 
   export let data = Promise.resolve([]);
 

--- a/src/components/customVegaFunctions.js
+++ b/src/components/customVegaFunctions.js
@@ -1,0 +1,12 @@
+import { timeFormat } from 'd3-time-format';
+
+const cache = new Map();
+
+export function cachedTime(datum, params) {
+  if (cache.has(params)) {
+    return cache.get(params)(datum);
+  }
+  const formatter = timeFormat(params);
+  cache.set(params, formatter);
+  return formatter(datum);
+}

--- a/src/components/customVegaFunctions.js
+++ b/src/components/customVegaFunctions.js
@@ -1,12 +1,24 @@
 import { timeFormat } from 'd3-time-format';
+import { format } from 'd3-format';
 
 const cache = new Map();
 
 export function cachedTime(datum, params) {
-  if (cache.has(params)) {
-    return cache.get(params)(datum);
+  const key = `d:${params}`;
+  if (cache.has(key)) {
+    return cache.get(key)(datum);
   }
   const formatter = timeFormat(params);
-  cache.set(params, formatter);
+  cache.set(key, formatter);
+  return formatter(datum);
+}
+
+export function cachedNumber(datum, params) {
+  const key = `n:${params}`;
+  if (cache.has(key)) {
+    return cache.get(key)(datum);
+  }
+  const formatter = format(params);
+  cache.set(key, formatter);
   return formatter(datum);
 }

--- a/src/modes/overview/SmallMultiplesPanel.svelte
+++ b/src/modes/overview/SmallMultiplesPanel.svelte
@@ -44,7 +44,7 @@
 
   const throttled = throttle((value) => {
     highlightTimeValue = value;
-  }, 50);
+  }, 25);
 
   function onHighlight(e) {
     const value = resolveHighlightedTimeValue(e);

--- a/src/modes/overview/vegaSpec.js
+++ b/src/modes/overview/vegaSpec.js
@@ -162,7 +162,7 @@ export function createSpec(sensor, selections, dateRange, valuePatch) {
               clamp: true,
             },
             axis: {
-              ...(isPercentage ? { format: '.1%' } : {}),
+              ...(isPercentage ? { format: '.1%', formatType: 'cachedNumber' } : {}),
               title: null,
               tickCount: 3,
               minExtent: 25,

--- a/src/modes/overview/vegaSpec.js
+++ b/src/modes/overview/vegaSpec.js
@@ -136,7 +136,7 @@ export function createSpec(sensor, selections, dateRange, valuePatch) {
         axis: {
           title: null,
           format: '%m/%d',
-          formatType: 'time',
+          formatType: 'cachedTime',
           tickCount: 'month',
         },
         scale: dateRange
@@ -233,6 +233,7 @@ export function createSpec(sensor, selections, dateRange, valuePatch) {
       CURRENT_DATE_HIGHLIGHT,
     ],
     config: {
+      customFormatTypes: true,
       legend: {
         disable: true,
       },

--- a/src/modes/overview/vegaSpec.js
+++ b/src/modes/overview/vegaSpec.js
@@ -147,6 +147,8 @@ export function createSpec(sensor, selections, dateRange, valuePatch) {
       },
     },
     layer: [
+      // complicated construct to have proper typings
+      ...(sensor.hasStdErr ? [stdErrLayer] : []),
       {
         mark: {
           type: 'line',
@@ -176,13 +178,22 @@ export function createSpec(sensor, selections, dateRange, valuePatch) {
             type: 'single',
             empty: 'none',
             on: 'mouseover',
-            nearest: true,
+            nearest: false,
             clear: 'mouseout',
           },
         },
+        // use vertical rule for selection, since nearest is a real performance bummer
+        mark: {
+          type: 'rule',
+          strokeWidth: 2.5,
+          color: 'white',
+          opacity: 0.001,
+          tooltip: true,
+        },
+      },
+      {
         mark: {
           type: 'point',
-          tooltip: true,
           radius: 1,
           stroke: null,
           fill: 'grey',
@@ -207,23 +218,24 @@ export function createSpec(sensor, selections, dateRange, valuePatch) {
           },
         },
       },
-      // complicated construct to have proper typings
-      ...(sensor.hasStdErr ? [stdErrLayer] : []),
       {
-        transform: [
-          {
-            filter: {
-              or: [
-                {
-                  selection: 'highlight',
-                },
-                'datum.time_value == highlightTimeValue',
-              ],
-            },
-          },
-        ],
-        mark: 'rule',
+        mark: {
+          type: 'rule',
+        },
         encoding: {
+          opacity: {
+            condition: [
+              {
+                selection: 'highlight',
+                value: 1,
+              },
+              {
+                test: 'datum.time_value == highlightTimeValue',
+                value: 1,
+              },
+            ],
+            value: 0,
+          },
           y: {
             field: yField,
             type: 'quantitative',

--- a/src/modes/single/SingleLocation.svelte
+++ b/src/modes/single/SingleLocation.svelte
@@ -19,7 +19,7 @@
 
   const throttled = throttle((value) => {
     highlightTimeValue = value;
-  }, 50);
+  }, 25);
 
   function onHighlight(e) {
     const value = resolveHighlightedTimeValue(e);


### PR DESCRIPTION
**Prerequisites**:

- [x] Unless it is a hotfix it should be merged against the `dev` branch
- [x] Branch is up-to-date with the branch to be merged with, i.e. `dev`
- [x] Build is successful
- [x] Code is cleaned up and formatted

### Summary

improves the Vega highlighted performance. The main bottleneck was that Vega computes the Voronoi map for (https://vega.github.io/vega-lite/docs/nearest.html) on each highlight update. I deactivated nearest and tried to simulate it by adding hidden vertical lines that are used now for selection. Moreover, I implemented some simple date formatting caching.