### PR TITLE
making toggle selection darker

### DIFF
--- a/src/styles/pg-button.css
+++ b/src/styles/pg-button.css
@@ -86,12 +86,9 @@
 }
 
 .pg-button-vertical-group > .selected,
-.pg-button-group > .selected {
-  background-color: #f2f2f2;
-}
-
+.pg-button-group > .selected,
 .pg-button-group > .selected:focus {
-  background-color: #f2f2f2 !important;
+  background-color: #b9b7b7 !important;
 }
 
 .pg-button-group .pg-button.selected:nth-child(n + 2) {


### PR DESCRIPTION
closes #477 

**Prerequisites**:

- [x] Unless it is a hotfix it should be merged against the `dev` branch
- [x] Branch is up-to-date with the branch to be merged with, i.e. `dev`
- [x] Build is successful
- [x] Code is cleaned up and formatted

### Summary
Makes the background darker on the toggle buttons "Incidence" vs "Cumulative" and "Counts" vs "Ratios" when selected

Before:
<img width="217" alt="Screen Shot 2020-10-14 at 4 02 16 PM" src="https://user-images.githubusercontent.com/14190352/96050282-5b2bdc00-0e47-11eb-8468-b8db83b50130.png">

After:
<img width="193" alt="Screen Shot 2020-10-14 at 4 02 22 PM" src="https://user-images.githubusercontent.com/14190352/96050293-5ff09000-0e47-11eb-8c6a-f4677780855d.png">

