### PR TITLE
Add day ticks and week gridlines for Detail view.

### DIFF
--- a/src/components/DetailView/vegaSpec.js
+++ b/src/components/DetailView/vegaSpec.js
@@ -1,4 +1,5 @@
 import merge from 'lodash-es/merge';
+
 /**
  * @type {import('vega-lite/build/src/spec').LayerSpec | import('vega-lite/build/src/spec').UnitSpec}
  */
@@ -68,24 +69,20 @@ export const xDateEncoding = {
   field: 'date_value',
   type: 'temporal',
   axis: {
+    orient: 'bottom',
+    labels: false,
     title: null,
-    format: '%m/%d',
-    formatType: 'time',
-    tickCount: 'day',
-    grid: false,
-    labelSeparation: 10, // Should be based on font size.
   },
 };
 
 const xDateRangeEncoding = {
-  field: 'date_value',
-  type: 'temporal',
+  ...xDateEncoding,
   axis: {
     title: null,
     format: '%m/%d',
     formatType: 'time',
     tickCount: 'week',
-    grid: false,
+    grid: true,
     labelSeparation: 10, // Should be based on font size.
   },
 };
@@ -136,6 +133,7 @@ export function createSpec(sensor, primaryValue, selections, initialSelection) {
             scale: { domain: { selection: 'brush' } },
           },
         },
+        resolve: { axis: { x: 'independent' } },
         layer: [
           {
             mark: {
@@ -144,6 +142,17 @@ export function createSpec(sensor, primaryValue, selections, initialSelection) {
             },
             encoding: {
               color: colorEncoding(selections),
+              x: {
+                ...xDateEncoding,
+                axis: {
+                  title: null,
+                  format: '%m/%d',
+                  formatType: 'time',
+                  tickCount: 'week',
+                  grid: true,
+                  labelSeparation: 10, // Should be based on font size.
+                },
+              },
               y: {
                 field: primaryValue,
                 type: 'quantitative',
@@ -174,6 +183,19 @@ export function createSpec(sensor, primaryValue, selections, initialSelection) {
             encoding: {
               color: {
                 field: 'geo_value',
+              },
+              x: {
+                ...xDateEncoding,
+                axis: {
+                  title: null,
+                  orient: 'bottom',
+                  labels: false,
+                  format: '%m/%d',
+                  formatType: 'time',
+                  tickCount: 'day',
+                  grid: false,
+                  labelSeparation: 10, // Should be based on font size.
+                },
               },
               y: {
                 field: primaryValue,

--- a/src/components/DetailView/vegaSpec.js
+++ b/src/components/DetailView/vegaSpec.js
@@ -81,6 +81,7 @@ export const xDateEncoding = {
 const xDateRangeEncoding = {
   ...xDateEncoding,
   axis: {
+    orient: 'bottom',
     title: null,
     format: '%m/%d',
     formatType: 'time',
@@ -146,15 +147,7 @@ export function createSpec(sensor, primaryValue, selections, initialSelection) {
             encoding: {
               color: colorEncoding(selections),
               x: {
-                ...xDateEncoding,
-                axis: {
-                  title: null,
-                  format: '%m/%d',
-                  formatType: 'time',
-                  tickCount: 'week',
-                  grid: true,
-                  labelSeparation: 10, // Should be based on font size.
-                },
+                ...xDateRangeEncoding,
               },
               y: {
                 field: primaryValue,
@@ -188,16 +181,12 @@ export function createSpec(sensor, primaryValue, selections, initialSelection) {
                 field: 'geo_value',
               },
               x: {
-                ...xDateEncoding,
+                ...xDateRangeEncoding,
                 axis: {
-                  title: null,
-                  orient: 'bottom',
+                  ...xDateRangeEncoding.axis,
                   labels: false,
-                  format: '%m/%d',
-                  formatType: 'time',
-                  tickCount: 'day',
                   grid: false,
-                  labelSeparation: 10, // Should be based on font size.
+                  tickCount: 'day',
                 },
               },
               y: {


### PR DESCRIPTION
closes #563

**Prerequisites**:

- [x] Unless it is a hotfix it should be merged against the `dev` branch
- [x] Branch is up-to-date with the branch to be merged with, i.e. `dev`
- [x] Build is successful
- [x] Code is cleaned up and formatted

### Summary

Adds day ticks to main chart, and adds week gridlines to both main chart and date range selector.
