### PR TITLE
improve vega tooltip styling

### DIFF
--- a/src/styles/tooltip.css
+++ b/src/styles/tooltip.css
@@ -2,4 +2,7 @@
   transition: unset !important;
   padding: 8px;
   z-index: 5000;
+  border: 1px solid gray;
+  border-radius: 4px;
+  opacity: 0.93;
 }


### PR DESCRIPTION
closes <!--list issues closed by this PR -->

**Prerequisites**:

- [ x] Unless it is a hotfix it should be merged against the `dev` branch
- [ x] Branch is up-to-date with the branch to be merged with, i.e. `dev`
- [x ] Build is successful
- [ x] Code is cleaned up and formatted

### Summary

Simply darkened the border to 'gray'.  Appears to match the map tooltip style.  Border radius of 4px appears unchanged from the default.   

I also added a small amount of transparency so you can vaguely see what is covered up by the tooltip.

![image](https://user-images.githubusercontent.com/570125/97223110-b1810f00-17a5-11eb-8d69-b75e8eaf3996.png)

