### PR TITLE
Use correct field when computing max of values.

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -4,7 +4,7 @@ module.exports = {
     '^.+\\.js$': 'babel-jest',
   },
   // // transform all files including node modules
-  transformIgnorePatterns: ['node_modules/(?!(svelte|svelte-icons)/)'],
+  transformIgnorePatterns: ['node_modules/(?!(svelte|svelte-icons|lodash-es)/)'],
   moduleFileExtensions: ['js', 'svelte'],
   moduleNameMapper: {
     // special module loading

--- a/src/components/Vega.svelte
+++ b/src/components/Vega.svelte
@@ -2,10 +2,9 @@
   import { onMount, onDestroy, createEventDispatcher, afterUpdate } from 'svelte';
   import embed from 'vega-embed';
   import { Error, expressionFunction } from 'vega';
-  import { observeResize, unobserveResize } from '../util';
+  import { observeResize, unobserveResize, debouncedResize } from '../util';
   import { createVegaTooltipAdapter } from './tooltipUtils';
   import { cachedTime, cachedNumber } from './customVegaFunctions';
-  import { debounce } from 'lodash-es';
 
   expressionFunction('cachedTime', cachedTime);
   expressionFunction('cachedNumber', cachedNumber);
@@ -237,10 +236,6 @@
       updateSpec(spec);
     }
   });
-
-  const debouncedResize = debounce(() => {
-    window.dispatchEvent(new Event('resize'));
-  }, 250);
 
   afterUpdate(() => {
     debouncedResize();

--- a/src/modes/top10/Top10.svelte
+++ b/src/modes/top10/Top10.svelte
@@ -174,12 +174,19 @@
     return data;
   });
 
-  function maxNested(rows) {
-    return rows.flat().reduce((acc, v) => Math.max(acc, v.value), 0);
+  // Returns the max value for all rows of all locations.
+  // arrayOfRows is an array of top locations, and for each location, the rows of that location.
+  // field is the name of the field to check.  pValue is auto-replaced with value.
+  function maxNested(arrayOfRows, field) {
+    if (arrayOfRows.length === 0) {
+      return 0;
+    }
+    field = field === 'pValue' ? 'value' : field;
+    return arrayOfRows.flat().reduce((acc, v) => Math.max(acc, v[field] != null ? v[field] : 0), 0);
   }
 
   // compute local maxima
-  $: primaryDomain = Promise.all(primaryData).then((rows) => [0, maxNested(rows)]);
+  $: primaryDomain = Promise.all(primaryData).then((rows) => [0, maxNested(rows, primaryField)]);
 
   $: otherDataAndDomain = otherSensors.map((sensor) => {
     const data = sortedRows.map((row) =>
@@ -187,7 +194,8 @@
         geo_value: row.propertyId,
       }).then((r) => addMissing(r)),
     );
-    const domain = Promise.all(data).then((rows) => [0, maxNested(rows)]);
+    const field = primaryValue(sensor, ratioOptions);
+    const domain = Promise.all(data).then((rows) => [0, maxNested(rows, field)]);
     return { data, domain };
   });
 

--- a/src/util.js
+++ b/src/util.js
@@ -1,5 +1,6 @@
 import { rgb, hsl } from 'd3-color';
 import ResizeObserver from 'resize-observer-polyfill';
+import { debounce } from 'lodash-es';
 
 export function getTextColorBasedOnBackground(bgColor) {
   const color = hsl(bgColor);
@@ -52,3 +53,16 @@ export function unobserveResize(element) {
   observerListeners.delete(element);
   observer.unobserve(element);
 }
+
+/**
+ * Returns a function that dispatches a resize event
+ * but debounced so that it will only be sent if there
+ * is no previous call within the debounce time, 100ms.
+ */
+export const debouncedResize = debounce(
+  () => {
+    window.dispatchEvent(new Event('resize'));
+  },
+  100,
+  { leading: false, trailing: true },
+);

--- a/src/util.js
+++ b/src/util.js
@@ -1,6 +1,6 @@
 import { rgb, hsl } from 'd3-color';
 import ResizeObserver from 'resize-observer-polyfill';
-import { debounce } from 'lodash-es';
+import debounce from 'lodash-es/debounce';
 
 export function getTextColorBasedOnBackground(bgColor) {
   const color = hsl(bgColor);


### PR DESCRIPTION
partly fixes #615

**Prerequisites**:

- [x] Unless it is a hotfix it should be merged against the `dev` branch
- [x] Branch is up-to-date with the branch to be merged with, i.e. `dev`
- [x] Build is successful
- [x] Code is cleaned up and formatted

### Summary

Instead of always using 'value', use the primaryField (with 'pValue' replaced with 'value').
Do this for the main sensor and 'others'.
Also globalizes debouncedResize, to reduce refreshes a bit.