### PR TITLE
feat: limit add another to same geo level

### DIFF
--- a/src/components/Search.svelte
+++ b/src/components/Search.svelte
@@ -47,8 +47,8 @@
   /**
    * @type {any[]}
    */
-  export let selectedItems = [];
-  $: multiple = selectedItems.length > 0;
+  export let selectedItems = null;
+  $: multiple = selectedItems != null;
   export let maxSelections = Number.POSITIVE_INFINITY;
 
   let text;
@@ -98,7 +98,7 @@
     // store reference to the origial item
     item,
   }));
-  $: selectedLabelLookup = new Set(selectedItems.map((s) => labelFunction(s)));
+  $: selectedLabelLookup = new Set((selectedItems || []).map((s) => labelFunction(s)));
 
   function limitListItems(items) {
     if (maxItemsToShowInList <= 0 || items.length < maxItemsToShowInList) {
@@ -448,7 +448,7 @@
   <button class="search-button" on:click={focusSearch} title="Show Search Field" aria-label="Show Search Field">
     <IoIosSearch />
   </button>
-  {#if multiple}
+  {#if multiple && selectedItems.length > 0}
     <div class="search-tags">
       {#each selectedItems as selectedItem}
         <div class="search-tag" style="border-color: {colorFieldName ? selectedItem[colorFieldName] : undefined}">

--- a/src/components/Search.svelte
+++ b/src/components/Search.svelte
@@ -8,6 +8,12 @@
   // the list of items  the user can select from
   export let items;
 
+  /**
+   * custom filter for visible items
+   * @type {(item) => boolean}
+   */
+  export let filterItem = null;
+
   // field of each item that's used for the labels in the list
   export let labelFieldName = undefined;
 
@@ -120,7 +126,9 @@
 
   function resetItems() {
     const matchingItems =
-      selectedLabelLookup.size > 0 ? listItems.filter((d) => !selectedLabelLookup.has(d.label)) : listItems;
+      selectedLabelLookup.size > 0 || filterItem != null
+        ? listItems.filter((d) => !selectedLabelLookup.has(d.label) && (filterItem == null || filterItem(d.item)))
+        : listItems;
     filteredListItems = limitListItems(matchingItems);
     hiddenFilteredListItems = matchingItems.length - filteredListItems.length;
   }
@@ -140,7 +148,9 @@
     const matchingItems = listItems.filter((listItem) => {
       const itemKeywords = listItem.keywords;
       return (
-        searchWords.every((searchWord) => itemKeywords.includes(searchWord)) && !selectedLabelLookup.has(listItem.label)
+        searchWords.every((searchWord) => itemKeywords.includes(searchWord)) &&
+        !selectedLabelLookup.has(listItem.label) &&
+        (filterItem == null || filterItem(listItem.item))
       );
     });
 

--- a/src/modes/overview/AddAnother.svelte
+++ b/src/modes/overview/AddAnother.svelte
@@ -18,7 +18,7 @@
     (d) =>
       d.level !== levelMegaCounty.id &&
       !selections.some((s) => s.info.id === d.id) &&
-      selections.some((s) => s.info.level === d.level), // filter to same level as selection
+      (selections.length === 0 || selections.some((s) => s.info.level === d.level)), // filter to same level as selection
   );
 
   $: possibleRecent = $recentRegionInfos.filter((d) => !selections.some((s) => s.info.id === d.id));

--- a/src/modes/overview/AddAnother.svelte
+++ b/src/modes/overview/AddAnother.svelte
@@ -15,7 +15,10 @@
   export let selections = [];
 
   $: possibleInfos = regionSearchList.filter(
-    (d) => d.level !== levelMegaCounty.id && !selections.some((s) => s.info.id === d.id),
+    (d) =>
+      d.level !== levelMegaCounty.id &&
+      !selections.some((s) => s.info.id === d.id) &&
+      selections.some((s) => s.info.level === d.level), // filter to same level as selection
   );
 
   $: possibleRecent = $recentRegionInfos.filter((d) => !selections.some((s) => s.info.id === d.id));

--- a/src/modes/single/SingleLocation.svelte
+++ b/src/modes/single/SingleLocation.svelte
@@ -35,6 +35,11 @@
       debouncedHighlightTime(value);
     }
   }
+
+  $: selectedLevels = new Set($currentMultiSelection.map((d) => d.info.level));
+  function filterItem(item) {
+    return selectedLevels.size === 0 || selectedLevels.has(item.level);
+  }
 </script>
 
 <style>
@@ -102,6 +107,7 @@
     labelFieldName="displayName"
     maxItemsToShowInList="5"
     colorFieldName="color"
+    {filterItem}
     maxSelections={Math.min(selectionColors.length + 1, 4)}
     on:add={(e) => addCompare(e.detail)}
     on:remove={(e) => removeCompare(e.detail.info)}


### PR DESCRIPTION
closes #624

**Prerequisites**:

- [x] Unless it is a hotfix it should be merged against the `dev` branch
- [x] Branch is up-to-date with the branch to be merged with, i.e. `dev`
- [x] Build is successful
- [x] Code is cleaned up and formatted

### Summary

limits the possible items in the add another search box to more of the same level, e.g. here states:

![image](https://user-images.githubusercontent.com/4129778/98979144-fbc5f800-24e8-11eb-97c6-556aa76ec753.png)
