### PR TITLE
feat: restore focus upon dialog close

### DIFF
--- a/src/components/DetailView/DetailView.svelte
+++ b/src/components/DetailView/DetailView.svelte
@@ -74,17 +74,27 @@
   function onEscCheck(e) {
     if (e.key === 'Escape' || e.key === 'Esc') {
       trackEvent('detail-view', 'close', 'keyboard');
+      restoreFocus();
       dispatch('close');
     }
   }
 
   let close = null;
+  let oldFocus = null;
 
   onMount(() => {
     if (close) {
+      oldFocus = document.activeElement;
       close.focus();
     }
   });
+
+  function restoreFocus() {
+    if (oldFocus) {
+      oldFocus.focus();
+      oldFocus = null;
+    }
+  }
 
   // Reference to the vega chart component.
   let vegaRef = null;
@@ -180,6 +190,7 @@
       class="pg-button pg-button-circle info"
       on:click={() => {
         trackEvent('detail-view', 'close', 'button');
+        restoreFocus();
         dispatch('close');
       }}
       title="Close this detail view">

--- a/src/components/InfoDialog.svelte
+++ b/src/components/InfoDialog.svelte
@@ -10,6 +10,7 @@
   } from '../stores';
 
   let close = null;
+  let oldFocus = null;
 
   /**
    * @param {KeyboardEvent} e
@@ -19,13 +20,22 @@
       return;
     }
     if (e.key === 'Escape' || e.key === 'Esc') {
+      restoreFocus();
       currentInfoSensor.set(null);
     }
   }
 
   $: {
     if ($currentInfoSensor && close) {
+      oldFocus = document.activeElement;
       close.focus();
+    }
+  }
+
+  function restoreFocus() {
+    if (oldFocus) {
+      oldFocus.focus();
+      oldFocus = null;
     }
   }
 
@@ -38,6 +48,7 @@
     // switch to export mode
     currentMode.set(modeByID.export);
     currentInfoSensor.set(null);
+    oldFocus = null;
   }
 </script>
 
@@ -99,6 +110,7 @@
       bind:this={close}
       class="pg-button close"
       on:click={() => {
+        restoreFocus();
         currentInfoSensor.set(null);
       }}
       title="Close this popup">


### PR DESCRIPTION
closes #598

**Prerequisites**:

- [x] Unless it is a hotfix it should be merged against the `dev` branch
- [x] Branch is up-to-date with the branch to be merged with, i.e. `dev`
- [x] Build is successful
- [x] Code is cleaned up and formatted

### Summary

restores the old focus upon closing a dialog which forces the focus on the close button.

![focus](https://user-images.githubusercontent.com/4129778/98984307-09cb4700-24f0-11eb-9657-4c44e1b863c3.gif)
