### PR TITLE
fix: date range initial selection was lost

### DIFF
--- a/src/components/DetailView/vegaSpec.js
+++ b/src/components/DetailView/vegaSpec.js
@@ -131,7 +131,21 @@ export function createSpec(sensor, primaryValue, selections, initialSelection, t
       lineHeight: 22,
       color: '#666',
     },
-    data: { name: 'values' },
+    data: {
+      name: 'values',
+      values: initialSelection
+        ? [
+            {
+              date_value: initialSelection[0],
+              value: 0,
+            },
+            {
+              date_value: initialSelection[1],
+              value: 1,
+            },
+          ]
+        : [],
+    },
     autosize: {
       type: 'none',
       contains: 'padding',
@@ -352,7 +366,7 @@ export function patchSpec(spec, size) {
   return merge({}, spec, {
     vconcat: [
       {
-        height: size.height - RANGE_SELECTOR_HEIGHT - OFFSET_Y,
+        height: Math.floor(size.height - RANGE_SELECTOR_HEIGHT - OFFSET_Y),
       },
       {
         height: RANGE_SELECTOR_HEIGHT,


### PR DESCRIPTION
**Prerequisites**:

- [x] Unless it is a hotfix it should be merged against the `dev` branch
- [x] Branch is up-to-date with the branch to be merged with, i.e. `dev`
- [x] Build is successful
- [x] Code is cleaned up and formatted

### Summary

fix that the initial date range is selected again at the beginning.

![image](https://user-images.githubusercontent.com/4129778/99278111-a6e1f480-27fc-11eb-8be9-482c9750df95.png)

the solution was somehow to define a "dummy" data such that the scale has always some date range to convert dates to pixels. As an alternative if you change `autoSize.type` back to `pad` you also don't have the problem (don't know why tho)