### PR TITLE
more robust missing meta data handling

### DIFF
--- a/src/components/MapBox/colors.js
+++ b/src/components/MapBox/colors.js
@@ -13,6 +13,19 @@ const TICK_COUNT = 7;
  * @typedef {import('../../stores/constants').SensorEntry} SensorEntry
  */
 
+const DEFAULT_STATS = { min: 0, max: 100, mean: 50, std: 10 };
+
+function resolveStats(statsLookup, key) {
+  if (!statsLookup || !statsLookup.has(key)) {
+    return DEFAULT_STATS;
+  }
+  const entry = statsLookup.get(key);
+  if ([entry.max, entry.std, entry.mean].some((d) => d == null || Number.isNaN(d))) {
+    console.warn('invalid stats detected for', key);
+    return DEFAULT_STATS;
+  }
+  return entry;
+}
 /**
  * @param {*} statsLookup
  * @param {SensorEntry} sensorEntry
@@ -27,7 +40,7 @@ export function determineMinMax(statsLookup, sensorEntry, level, signalOptions, 
     if (sensorEntry.isCasesOrDeath) {
       key += `_${primaryValue(sensorEntry, signalOptions)}`;
     }
-    const stats = statsLookup.get(key);
+    const stats = resolveStats(statsLookup, key);
     if (useMax) {
       return [0, stats.max];
     }
@@ -37,7 +50,7 @@ export function determineMinMax(statsLookup, sensorEntry, level, signalOptions, 
   if (sensorEntry.isCasesOrDeath) {
     key += `_${primaryValue(sensorEntry, signalOptions)}`;
   }
-  const stats = statsLookup.get(key);
+  const stats = resolveStats(statsLookup, key);
   if (useMax) {
     return [0, stats.max];
   }

--- a/src/modes/exportdata/ExportData.svelte
+++ b/src/modes/exportdata/ExportData.svelte
@@ -271,14 +271,14 @@
       <Datepicker
         bind:selected={startDate}
         start={source ? source.minTime : new Date()}
-        end={minDate(endDate, source ? source.maxTime : new Date())}
+        end={source ? minDate(endDate, source.maxTime) : endDate}
         formattedSelected={iso(startDate)}>
         <button aria-label="selected start date" class="pg-button" on:>{iso(startDate)}</button>
       </Datepicker>
       -
       <Datepicker
         bind:selected={endDate}
-        start={maxDate(startDate, source ? source.minTime : new Date())}
+        start={source ? maxDate(startDate, source.minTime) : startDate}
         end={source ? source.maxTime : new Date()}
         formattedSelected={iso(endDate)}>
         <button aria-label="selected end date" class="pg-button" on:>{iso(endDate)}</button>


### PR DESCRIPTION
**Prerequisites**:

- [x] Unless it is a hotfix it should be merged against the `dev` branch
- [x] Branch is up-to-date with the branch to be merged with, i.e. `dev`
- [x] Build is successful
- [x] Code is cleaned up and formatted

### Summary

improves the handling when no signal meta data is found in the API (e.g, with the current bar visits and other signals), at least it won't break the app anymore. 

fixes some race condition in loading the export tab directly