### PR TITLE
Improve layout and alignment of top-10 tab

### DIFF
--- a/src/modes/top10/Top10.svelte
+++ b/src/modes/top10/Top10.svelte
@@ -271,10 +271,6 @@
     padding-top: 1em;
   }
 
-  td,
-  th {
-  }
-
   .table > table {
     border-spacing: 1em 0.5em;
     width: 100%;

--- a/src/modes/top10/Top10.svelte
+++ b/src/modes/top10/Top10.svelte
@@ -292,13 +292,13 @@
   }
 
   table .name {
-    width: 20em;
+    width: 10em;
     text-align: left;
     white-space: nowrap;
   }
 
   table .table-pop-column {
-    width: 5em;
+    width: 7em;
     text-align: right;
   }
 
@@ -308,17 +308,16 @@
   }
 
   table .main-indicator {
-    width: 30em;
+    width: 40em;
     text-align: right;
   }
 
   table .other-indicator {
-    width: 30em;
+    width: 40em;
     text-align: right;
   }
 
   table .add-column-container {
-    width: 30em;
     text-align: left;
   }
 

--- a/src/modes/top10/Top10.svelte
+++ b/src/modes/top10/Top10.svelte
@@ -273,11 +273,10 @@
 
   td,
   th {
-    border: 0;
   }
 
   .table > table {
-    border-collapse: collapse;
+    border-spacing: 1em 0.5em;
     width: 100%;
     overflow: unset;
   }
@@ -285,6 +284,42 @@
   table {
     padding: 1em;
     font-size: 1.2em;
+  }
+
+  table .rank {
+    width: 1em;
+    text-align: right;
+  }
+
+  table .name {
+    width: 20em;
+    text-align: left;
+    white-space: nowrap;
+  }
+
+  table .table-pop-column {
+    width: 5em;
+    text-align: right;
+  }
+
+  table th {
+    text-align: right;
+    white-space: nowrap;
+  }
+
+  table .main-indicator {
+    width: 30em;
+    text-align: right;
+  }
+
+  table .other-indicator {
+    width: 30em;
+    text-align: right;
+  }
+
+  table .add-column-container {
+    width: 30em;
+    text-align: left;
   }
 
   .go-to-map-pin {
@@ -343,8 +378,8 @@
 
   .remove-column {
     position: absolute;
-    right: 0.2em;
-    top: 0.2em;
+    right: 0;
+    top: -2em;
     font-size: 0.7rem;
   }
 
@@ -376,8 +411,8 @@
     <table>
       <thead>
         <tr>
-          <th>#</th>
-          <th>
+          <th class="rank">#</th>
+          <th class="name">
             <Top10SortHint
               label="Name"
               on:click={() => sortClick('name')}
@@ -395,7 +430,7 @@
               Pop.
             </Top10SortHint>
           </th>
-          <th colspan={primary.isCasesOrDeath ? 3 : 2}>
+          <th class="main-indicator" colspan={primary.isCasesOrDeath ? 3 : 2}>
             <Top10SortHint
               label={primary.name}
               on:click={() => sortClick('primary', true)}
@@ -405,7 +440,7 @@
             </Top10SortHint>
           </th>
           {#each otherSensors as s, i}
-            <th colspan={s.isCasesOrDeath ? 3 : 2}>
+            <th class="other-indicator" colspan={s.isCasesOrDeath ? 3 : 2}>
               <Top10SortHint
                 label={s.name}
                 on:click={() => sortClick(i, true)}
@@ -445,8 +480,8 @@
       <tbody>
         {#each sortedRows as row, i}
           <tr class:selected={row.propertyId === $currentRegion}>
-            <td>{row.rank}.</td>
-            <td>
+            <td class="rank">{row.rank}.</td>
+            <td class="name">
               {row.displayName}
               <span class="go-to-map-pin" on:click={jumpTo(row)} title="Show on Map">
                 <IoIosPin />

--- a/src/modes/top10/Top10Sensor.svelte
+++ b/src/modes/top10/Top10Sensor.svelte
@@ -58,7 +58,7 @@
   }
 
   .chart {
-    width: 18em;
+    width: 20em;
     height: 4em;
     position: relative;
     padding: 0;

--- a/src/modes/top10/Top10SortHint.svelte
+++ b/src/modes/top10/Top10SortHint.svelte
@@ -12,9 +12,6 @@
     position: relative;
   }
 
-  .hint-wrapper {
-  }
-
   .hint {
     display: inline-block;
     width: 1em;

--- a/src/modes/top10/Top10SortHint.svelte
+++ b/src/modes/top10/Top10SortHint.svelte
@@ -8,14 +8,15 @@
 
 <style>
   .root {
-    display: flex;
     cursor: pointer;
-    text-align: center;
-    justify-content: center;
     position: relative;
   }
 
+  .hint-wrapper {
+  }
+
   .hint {
+    display: inline-block;
     width: 1em;
   }
 </style>


### PR DESCRIPTION
closes #657 

**Prerequisites**:

- [x] Unless it is a hotfix it should be merged against the `dev` branch
- [x] Branch is up-to-date with the branch to be merged with, i.e. `dev`
- [x] Build is successful
- [x] Code is cleaned up and formatted

### Summary

Change the sizing and alignment of the top-10 table columns.  A max-width doesn't exactly work, but distributing the width over the table columns works reasonably well.  We could figure out how to expand the chart width to make the most of the available space, but currently they use a fixed width.