### PR TITLE
refactor: use vega resize method in case a resize of the container ha…

### DIFF
--- a/src/components/Vega.svelte
+++ b/src/components/Vega.svelte
@@ -222,6 +222,7 @@
   onMount(() => {
     size = root.getBoundingClientRect();
     observeResize(root, (s) => {
+      // check if size has changed by at least one pixel in width or height
       if (Math.abs(s.width - size.width) > 1 || Math.abs(s.height - size.height) > 1) {
         size = s;
         if (!patchSpec && vega) {
@@ -230,6 +231,8 @@
         }
       }
     });
+    // in case of a given patchSpec function, a new spec will be generated when the size changes
+    // So, if patchSpec is not given, we have to update the spec manually
     if (!patchSpec) {
       updateSpec(spec);
     }

--- a/src/util.js
+++ b/src/util.js
@@ -86,16 +86,3 @@ export function unobserveResize(element) {
   observerListeners.delete(element);
   observer.unobserve(element);
 }
-
-/**
- * Returns a function that dispatches a resize event
- * but debounced so that it will only be sent if there
- * is no previous call within the debounce time, 100ms.
- */
-export const debouncedResize = debounce(
-  () => {
-    window.dispatchEvent(new Event('resize'));
-  },
-  100,
-  { leading: false, trailing: true },
-);

--- a/src/util.js
+++ b/src/util.js
@@ -1,6 +1,5 @@
 import { rgb, hsl } from 'd3-color';
 import ResizeObserver from 'resize-observer-polyfill';
-import debounce from 'lodash-es/debounce';
 
 export function getTextColorBasedOnBackground(bgColor) {
   const color = hsl(bgColor);


### PR DESCRIPTION
…ppens

**Prerequisites**:

- [x] Unless it is a hotfix it should be merged against the `dev` branch
- [x] Branch is up-to-date with the branch to be merged with, i.e. `dev`
- [x] Build is successful
- [x] Code is cleaned up and formatted

### Summary

changes the logic of calling vega resize method when the container size changes. In addition, inititializes the width/height signal with the container information. 

pro: 
 * no triggering of resize event which will update all vega charts
 * no triggering of resize event which also affects the map (also listening to it)
 * less updates in general