### PR TITLE
feat: define default signal in google doc

### DIFF
--- a/src/stores/constants.js
+++ b/src/stores/constants.js
@@ -82,6 +82,7 @@ export function getLevelInfo(level) {
  * @property {Record<keyof EpiDataCasesOrDeathValues, string>} casesOrDeathSignals signal to load for cases or death
  * @property {)(v: number) => string)} colorScale
  * @property {string} credits
+ * @property {boolean?} default whether it should be default signal
  */
 
 /**
@@ -259,14 +260,6 @@ export const yesterdayDate = new Date(new Date().getTime() - 86400 * 1000);
 export const yesterday = Number.parseInt(formatAPITime(yesterdayDate), 10);
 
 export const DEFAULT_MODE = modeByID.overview;
-export const DEFAULT_SENSOR = (() => {
-  const defaultSensorId = 'doctor-visits';
-  const defaultSensor = sensorList.find((d) => d.id === defaultSensorId);
-  if (defaultSensor) {
-    return defaultSensor.key;
-  } else {
-    return sensorList[0].key;
-  }
-})();
+export const DEFAULT_SENSOR = (sensorList.find((d) => d.default) || sensorList[0]).key;
 export const DEFAULT_LEVEL = 'county';
 export const DEFAULT_ENCODING = 'color';

--- a/src/stores/constants.spec.js
+++ b/src/stores/constants.spec.js
@@ -1,11 +1,5 @@
 /// <reference types="jest" />
-import { DEFAULT_SENSOR, EPIDATA_CASES_OR_DEATH_VALUES, getLevelInfo, sensorList } from './constants';
-
-describe('DEFAULT_SENSOR', () => {
-  test('matches', () => {
-    expect(DEFAULT_SENSOR).toBe('doctor-visits-smoothed_adj_cli');
-  });
-});
+import { EPIDATA_CASES_OR_DEATH_VALUES, getLevelInfo, sensorList } from './constants';
 
 describe('sensorList', () => {
   test.each(sensorList.map((d) => [d]))('has structure %s', (sensor) => {


### PR DESCRIPTION
closes #680

**Prerequisites**:

- [x] Unless it is a hotfix it should be merged against the `dev` branch
- [x] Branch is up-to-date with the branch to be merged with, i.e. `dev`
- [x] Build is successful
- [x] Code is cleaned up and formatted

### Summary

uses the `default` flag from the google doc to define the default signal