### PR TITLE
feat: default ratio cases/deaths

### DIFF
--- a/src/components/EncodingOptions.svelte
+++ b/src/components/EncodingOptions.svelte
@@ -53,27 +53,27 @@
     <div aria-label="display counts or ratios per 100,000 people" class="uk-button-group">
       <button
         type="button"
-        aria-pressed={String(!$signalCasesOrDeathOptions.ratio)}
+        aria-pressed={String(!$signalCasesOrDeathOptions.incidence)}
         class="uk-button uk-button-default uk-button-small"
-        class:uk-active={!$signalCasesOrDeathOptions.ratio}
+        class:uk-active={!$signalCasesOrDeathOptions.incidence}
         on:click={() => {
-          if ($signalCasesOrDeathOptions.ratio) {
-            signalCasesOrDeathOptions.set({ ...$signalCasesOrDeathOptions, ratio: false });
-          }
-        }}>
-        Counts
-      </button>
-      <button
-        type="button"
-        aria-pressed={String($signalCasesOrDeathOptions.ratio)}
-        class="uk-button uk-button-default uk-button-small"
-        class:uk-active={$signalCasesOrDeathOptions.ratio}
-        on:click={() => {
-          if (!$signalCasesOrDeathOptions.ratio) {
-            signalCasesOrDeathOptions.set({ ...$signalCasesOrDeathOptions, ratio: true });
+          if ($signalCasesOrDeathOptions.incidence) {
+            signalCasesOrDeathOptions.set({ ...$signalCasesOrDeathOptions, incidence: false });
           }
         }}>
         Ratios (per 100,000)
+      </button>
+      <button
+        type="button"
+        aria-pressed={String($signalCasesOrDeathOptions.incidence)}
+        class="uk-button uk-button-default uk-button-small"
+        class:uk-active={$signalCasesOrDeathOptions.incidence}
+        on:click={() => {
+          if (!$signalCasesOrDeathOptions.incidence) {
+            signalCasesOrDeathOptions.set({ ...$signalCasesOrDeathOptions, incidence: true });
+          }
+        }}>
+        Counts
       </button>
     </div>
   </div>

--- a/src/components/MapBox/Tooltip.svelte
+++ b/src/components/MapBox/Tooltip.svelte
@@ -73,21 +73,23 @@
           </tr>
           <tr>
             <th>{formatTimeWithoutYear($currentDateObject)}</th>
-            <td class="right" style={!options.cumulative && !options.ratio ? colorScaleStyle(properties.count) : ''}>
+            <td class="right" style={!options.cumulative && options.incidence ? colorScaleStyle(properties.count) : ''}>
               {$currentSensorEntry.formatValue(properties.count)}
             </td>
             <td
               class="right"
-              style={!options.cumulative && options.ratio ? colorScaleStyle(properties.countRatio) : ''}>
+              style={!options.cumulative && !options.incidence ? colorScaleStyle(properties.countRatio) : ''}>
               {$currentSensorEntry.formatValue(properties.countRatio)}
             </td>
           </tr>
           <tr>
             <th>7-day avg</th>
-            <td class="right" style={!options.cumulative && !options.ratio ? colorScaleStyle(properties.avg) : ''}>
+            <td class="right" style={!options.cumulative && options.incidence ? colorScaleStyle(properties.avg) : ''}>
               {$currentSensorEntry.formatValue(properties.avg)}
             </td>
-            <td class="right" style={!options.cumulative && options.ratio ? colorScaleStyle(properties.avgRatio) : ''}>
+            <td
+              class="right"
+              style={!options.cumulative && !options.incidence ? colorScaleStyle(properties.avgRatio) : ''}>
               {$currentSensorEntry.formatValue(properties.avgRatio)}
             </td>
           </tr>
@@ -95,12 +97,12 @@
             <th>Cumulative {formatTimeWithoutYear($currentDateObject)}</th>
             <td
               class="right"
-              style={options.cumulative && !options.ratio ? colorScaleStyle(properties.countCumulative) : ''}>
+              style={options.cumulative && options.incidence ? colorScaleStyle(properties.countCumulative) : ''}>
               {$currentSensorEntry.formatValue(properties.countCumulative)}
             </td>
             <td
               class="right"
-              style={options.cumulative && options.ratio ? colorScaleStyle(properties.countRatioCumulative) : ''}>
+              style={options.cumulative && !options.incidence ? colorScaleStyle(properties.countRatioCumulative) : ''}>
               {$currentSensorEntry.formatValue(properties.countRatioCumulative)}
             </td>
           </tr>

--- a/src/data/index.js
+++ b/src/data/index.js
@@ -17,7 +17,7 @@ function processMetaData(meta) {
 
   sensorList.forEach((sEntry) => {
     // need to change mean / std for counts
-    if (sEntry.isCount) {
+    if (sEntry.isCount || sEntry.isCasesOrDeath) {
       loadCountSignal(sEntry, meta, timeMap, statsMap);
     } else {
       loadRegularSignal(sEntry, meta, timeMap, statsMap);

--- a/src/data/utils.js
+++ b/src/data/utils.js
@@ -9,9 +9,7 @@ import { timeParse, timeFormat } from 'd3-time-format';
  * @param {import('./fetchData').EpiDataRow[][]} data
  * @param {string[]} keys
  */
-export function combineSignals(data, keys, toKey = (d) => `${d.geo_value}@${d.time_value}`) {
-  const ref = data[0];
-
+export function combineSignals(data, ref, keys, toKey = (d) => `${d.geo_value}@${d.time_value}`) {
   const map = new Map(ref.map((d) => [toKey(d), d]));
   data.forEach((rows, i) => {
     const key = keys[i];

--- a/src/modes/overview/SmallMultiplesPanel.svelte
+++ b/src/modes/overview/SmallMultiplesPanel.svelte
@@ -121,7 +121,7 @@
             trackEvent('side-panel', 'set-sensor', s.sensor.key);
             currentSensor.set(s.sensor.key);
           }}>
-          {typeof s.sensor.mapTitleText === 'function' ? s.sensor.mapTitleText() : s.sensor.name}
+          {s.sensor.plotTitleText}
         </button>
         <div class="grow" />
         <div class="toolbar">

--- a/src/modes/single/SensorCard.svelte
+++ b/src/modes/single/SensorCard.svelte
@@ -152,9 +152,7 @@
 
 <section class="uk-card uk-card-body uk-card-default uk-card-small card" data-testid="sensor-{sensor.key}">
   <div class="uk-card-header">
-    <h3 class="uk-card-title uk-margin-remove-bottom">
-      {typeof sensor.mapTitleText === 'function' ? sensor.mapTitleText() : sensor.name}
-    </h3>
+    <h3 class="uk-card-title uk-margin-remove-bottom">{sensor.plotTitleText}</h3>
     <div class="toolbar">
       <InfoDialogButton {sensor} />
     </div>

--- a/src/modes/top10/Top10.svelte
+++ b/src/modes/top10/Top10.svelte
@@ -58,7 +58,7 @@
    */
   const ratioOptions = {
     cumulative: false,
-    ratio: true,
+    incidence: false,
   };
   $: primaryField = primaryValue(primary, ratioOptions);
   /**
@@ -355,7 +355,7 @@
                 on:click={() => sortClick('primary', true)}
                 sorted={sortCriteria === 'primary'}
                 desc={sortDirectionDesc}>
-                {typeof primary.mapTitleText === 'function' ? primary.mapTitleText(ratioOptions) : primary.name}
+                {primary.plotTitleText}
               </Top10SortHint>
             </th>
             {#each otherSensors as s, i}
@@ -365,7 +365,7 @@
                   on:click={() => sortClick(i, true)}
                   sorted={sortCriteria === i}
                   desc={sortDirectionDesc}>
-                  {typeof s.mapTitleText === 'function' ? s.mapTitleText(ratioOptions) : s.name}
+                  {primary.plotTitleText}
                   <button
                     class="remove-column"
                     title="Remove column"

--- a/src/stores/constants.js
+++ b/src/stores/constants.js
@@ -53,7 +53,7 @@ export function getLevelInfo(level) {
 /**
  * @typedef {object} CasesOrDeathOptions
  * @property {boolean} cumulative
- * @property {boolean} ratio
+ * @property {boolean} incidence
  */
 
 /**
@@ -68,6 +68,7 @@ export function getLevelInfo(level) {
  * @property {string[]} levels
  * @property {string | ((options?: CasesOrDeathOptions) => string)} tooltipText
  * @property {string | ((options?: CasesOrDeathOptions) => string)} mapTitleText
+ * @property {string} plotTitleText
  * @property {string} yAxis
  * @property {string} format
  * @property {(v: number) => string} formatValue
@@ -124,9 +125,9 @@ export function primaryValue(sensorEntry, sensorOptions) {
     return 'value';
   }
   if (sensorOptions.cumulative) {
-    return sensorOptions.ratio ? 'countRatioCumulative' : 'countCumulative';
+    return sensorOptions.incidence ? 'countCumulative' : 'countRatioCumulative';
   }
-  return sensorOptions.ratio ? 'avgRatio' : 'avg';
+  return sensorOptions.incidence ? 'avg' : 'avgRatio';
 }
 
 /**
@@ -164,30 +165,32 @@ export function extendSensorEntry(sensorEntry) {
     key,
     tooltipText: sensorEntry.tooltipText || mapTitle,
     credits: sensorEntry.credits || 'We are happy for you to use this data in products and publications.',
-    formatValue: sensorEntry.format === 'percent' ? percentFormatter : isCount ? countFormatter : rawFormatter,
+    formatValue:
+      sensorEntry.format === 'percent' ? percentFormatter : isCount || isCasesOrDeath ? countFormatter : rawFormatter,
     isCount,
     getType: (options) => getType(sensorEntry, options),
     isCasesOrDeath,
     colorScale: resolveColorScale(sensorEntry.colorScale),
     links: sensorEntry.links || [],
+    plotTitleText: sensorEntry.plotTitleText || sensorEntry.name,
     mapTitleText:
       typeof mapTitle === 'string'
         ? mapTitle
         : (options) => {
             // generate lookup function
             if (!options) {
-              return mapTitle.incidence;
+              return mapTitle[primaryValue(sensorEntry, {})];
             }
             if (options.cumulative) {
-              if (options.ratio) {
-                return mapTitle.ratioCumulative;
-              } else {
+              if (options.incidence) {
                 return mapTitle.incidenceCumulative;
+              } else {
+                return mapTitle.ratioCumulative;
               }
-            } else if (options.ratio) {
-              return mapTitle.ratio;
-            } else {
+            } else if (options.incidence) {
               return mapTitle.incidence;
+            } else {
+              return mapTitle.ratio;
             }
           },
   });

--- a/src/stores/ga.js
+++ b/src/stores/ga.js
@@ -76,7 +76,7 @@ appReady.subscribe((v) => {
       return;
     }
     trackEvent('signalCasesOrDeathOptions', 'cumulative', String(r.cumulative));
-    trackEvent('signalCasesOrDeathOptions', 'ratio', String(r.ratio));
+    trackEvent('signalCasesOrDeathOptions', 'ratio', String(!r.incidence));
   });
   currentInfoSensor.subscribe((r) => {
     if (initialRun) {

--- a/src/stores/index.js
+++ b/src/stores/index.js
@@ -73,9 +73,12 @@ export const currentLevel = writable(DEFAULT_LEVEL, (set) => {
 });
 
 // in case of a death signal whether to show cumulative data
+/**
+ * @type {import('svelte/store').Writable<import('./constants').CasesOrDeathOptions>}
+ */
 export const signalCasesOrDeathOptions = writable({
   cumulative: urlParams.has('signalC'),
-  ratio: urlParams.has('signalR'),
+  incidence: urlParams.has('signalI'),
 });
 
 export const currentSensorMapTitle = derived([currentSensorEntry, signalCasesOrDeathOptions], ([sensor, options]) =>
@@ -207,7 +210,7 @@ currentSensorEntry.subscribe((sensorEntry) => {
   if (!sensorEntry.isCasesOrDeath) {
     signalCasesOrDeathOptions.set({
       cumulative: false,
-      ratio: false,
+      incidence: false,
     });
   }
 
@@ -339,7 +342,7 @@ export const trackedUrlParams = derived(
       region: mode === modeByID.export || mode === modeByID.timelapse || !region ? null : region,
       date: mode === modeByID.export ? null : date,
       signalC: !inMapMode || !sensorEntry || !sensorEntry.isCasesOrDeath ? null : signalOptions.cumulative,
-      signalR: !inMapMode || !sensorEntry || !sensorEntry.isCasesOrDeath ? null : signalOptions.ratio,
+      signalI: !inMapMode || !sensorEntry || !sensorEntry.isCasesOrDeath ? null : signalOptions.incidence,
       encoding: !inMapMode || encoding === DEFAULT_ENCODING ? null : encoding,
       compare:
         (mode !== modeByID.overview && mode !== modeByID.single) || !compare


### PR DESCRIPTION
closes #536 

**Prerequisites**:

- [x] Unless it is a hotfix it should be merged against the `dev` branch
- [x] Branch is up-to-date with the branch to be merged with, i.e. `dev`
- [x] Build is successful
- [x] Code is cleaned up and formatted

### Summary

REQUIRES: the suggested changes in https://docs.google.com/document/d/1RLy4O-gtACVjLEVD_vxyPqvp9nWVhqEjoWAKi68RKpg/edit#

changes the default cases/deaths signal to be the ratio one: 

![image](https://user-images.githubusercontent.com/4129778/102631781-29234880-411c-11eb-9d52-9a832d58241d.png)

including side plots