### PR TITLE
feat: add special case for old safari

### DIFF
--- a/src/stores/index.js
+++ b/src/stores/index.js
@@ -230,9 +230,16 @@ currentSensorEntry.subscribe((sensorEntry) => {
 export const isMobileDevice = readable(false, (set) => {
   const isMobileQuery = window.matchMedia('only screen and (max-width: 767px)');
   set(isMobileQuery.matches);
-  isMobileQuery.addEventListener('change', (evt) => {
-    set(evt.matches);
-  });
+  if (typeof isMobileQuery.addEventListener === 'function') {
+    isMobileQuery.addEventListener('change', (evt) => {
+      set(evt.matches);
+    });
+  } else {
+    // deprecated but other version is not supported in Safari 13
+    isMobileQuery.addListener((e) => {
+      set(e.matches);
+    });
+  }
 });
 
 // export const isPortraitDevice = readable(false, (set) => {


### PR DESCRIPTION
closes #686

**Prerequisites**:

- [x] Unless it is a hotfix it should be merged against the `dev` branch
- [x] Branch is up-to-date with the branch to be merged with, i.e. `dev`
- [x] Build is successful
- [x] Code is cleaned up and formatted

### Summary

checks before using a `new` JS function which caused the error mentioned in the issue

note: cannot test it cause I don't have this safari version. 