### PR TITLE
unique bundle names

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,12 +14,16 @@
   },
   "main": "public/bundle.js",
   "files": [
-    "public"
+    "public/**.js",
+    "public/**.txt",
+    "public/**.css"
   ],
   "scripts": {
+    "clean": "rimraf \"*.zip\" \"*.tgz\" public",
     "gen": "node ./scripts/generateDescriptions.js",
     "process-geo": "node ./src/maps/process.js",
     "start": "npm run gen && cross-env NODE_ENV=development webpack-dev-server -d --open",
+    "prebuild": "npm run clean",
     "build": "npm run gen && cross-env NODE_ENV=production webpack -p",
     "watch": "cross-env NODE_ENV=development webpack --mode development -w",
     "deploy": "npm run build; gh-pages -d public",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
   "files": [
     "public/**.js",
     "public/**.txt",
-    "public/**.css"
+    "public/**.css",
+    "!public/wrapper.*"
   ],
   "scripts": {
     "clean": "rimraf \"*.zip\" \"*.tgz\" public",

--- a/src/modes/survey/questions.js
+++ b/src/modes/survey/questions.js
@@ -1,5 +1,6 @@
 import { sensorList } from '../../stores';
 import descriptions from './descriptions.generated.json';
+import '!file-loader?name=surveyquestions.raw.txt!./descriptions.raw.txt';
 
 export const overviewText = descriptions.overview;
 export const trendThreshold = descriptions.trendThreshold;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -22,8 +22,8 @@ module.exports = () => {
 
     output: {
       path: path.resolve(__dirname, 'public'),
-      filename: '[name].js',
-      chunkFilename: '[name].js',
+      filename: '[name].[contenthash].js',
+      chunkFilename: '[name].[contenthash].js',
     },
 
     resolve: {
@@ -175,9 +175,9 @@ module.exports = () => {
 
       new HtmlWebpackHarddiskPlugin(),
       new MiniCssExtractPlugin({
-        filename: '[name].css',
+        filename: '[name].[contenthash].css',
         ignoreOrder: true,
-        chunkFilename: '[name].css',
+        chunkFilename: '[name].[contenthash].css',
       }),
     ].filter(Boolean),
   };


### PR DESCRIPTION
**Prerequisites**:

- [x] Unless it is a hotfix it should be merged against the `dev` branch
- [x] Branch is up-to-date with the branch to be merged with, i.e. `dev`
- [x] Build is successful
- [x] Code is cleaned up and formatted

### Summary

creates unique bundle names by using webpacks `contenthash` within the file name. However, this requires https://github.com/cmu-delphi/www-main/pull/204 such that www-main also respects the new names.

This will avoid that the website and covidcast are out of sync on a client. A new version of the website will request a different filename from the server, thus a old browser cache hit won't be possible. An old version of the website will also request an old version of covidcast so also from this direction no problem anymore