### PR TITLE
feat: use UIKit scrollspy for lazy vega plots

### DIFF
--- a/src/components/Vega.svelte
+++ b/src/components/Vega.svelte
@@ -32,19 +32,26 @@
 
   /**
    * signals to dispatch
-   * @types {string[]}
+   * @type {string[]}
    */
   export let signalListeners = [];
   /**
    * data listeners to dispatch
-   * @types {string[]}
+   * @type {string[]}
    */
   export let dataListeners = [];
   /**
    * data listeners to dispatch
-   * @types {string[]}
+   * @type {string[]}
    */
   export let eventListeners = [];
+
+  /**
+   * if >= 0 enables scroll-spy behavior to lazy render the vega plot upon visibility
+   * the number represents the offset argument of UIkit.scrollspy
+   * @type {number}
+   */
+  export let scrollSpy = -1;
 
   let loading = false;
   let noData = false;
@@ -216,7 +223,9 @@
     });
   }
 
-  onMount(() => {
+  let scrollSpyHandler = null;
+
+  function initVegaContainer() {
     size = root.getBoundingClientRect();
     observeResize(root, (s) => {
       // check if size has changed by at least one pixel in width or height
@@ -233,10 +242,32 @@
     if (!patchSpec) {
       updateSpec(spec);
     }
+  }
+
+  onMount(() => {
+    if (scrollSpy >= 0) {
+      // use a scroll spy to find out whether we are visible
+      // eslint-disable-next-line no-undef
+      UIkit.scrollspy(root, {
+        offset: scrollSpy,
+      });
+      const handler = () => {
+        initVegaContainer();
+        root.removeEventListener('inview', handler); // once
+      };
+      root.addEventListener('inview', handler);
+    } else {
+      initVegaContainer();
+    }
   });
 
   onDestroy(() => {
     unobserveResize(root);
+
+    if (scrollSpyHandler) {
+      scrollSpyHandler.$destroy();
+      scrollSpyHandler = null;
+    }
     if (tooltipHandler) {
       tooltipHandler.destroy();
     }
@@ -253,7 +284,7 @@
 
 <div
   bind:this={root}
-  class="root"
+  class="root vega-embed"
   class:loading-bg={!hasError && loading}
   class:message-overlay={hasError || (noData && !loading)}
   data-message={message}

--- a/src/modes/survey/SurveyQuestion.svelte
+++ b/src/modes/survey/SurveyQuestion.svelte
@@ -191,6 +191,7 @@
     <Vega
       {spec}
       {data}
+      scrollSpy={100}
       signals={{ currentDate: date, maxDate, refDate }}
       tooltip={SurveyTooltip}
       tooltipProps={{ question }} />


### PR DESCRIPTION
**Prerequisites**:

- [x] Unless it is a hotfix it should be merged against the `dev` branch
- [x] Branch is up-to-date with the branch to be merged with, i.e. `dev`
- [x] Build is successful
- [x] Code is cleaned up and formatted

### Summary

uses https://getuikit.com/docs/scrollspy to only render vega plots that are visible, improving the initial loading time on the cost of the scrolling time. 