### PR TITLE
fix: empty tree loading

### DIFF
--- a/src/data/fetchData.js
+++ b/src/data/fetchData.js
@@ -80,6 +80,9 @@ function parseMultipleTreeData(d, signals, defaultSignalIndex, mixinData = {}) {
     return [];
   }
   const tree = d.epidata || [];
+  if (tree.length === 0 || (Array.isArray(tree[0]) && tree[0].length === 0)) {
+    return parseData({ ...d, epidata: [] }, mixinData);
+  }
   const split = signals.map((k) => tree[0][k]);
   const ref = split[defaultSignalIndex];
   const combined = combineSignals(split, ref, EPIDATA_CASES_OR_DEATH_VALUES, deriveCombineKey(mixinData));


### PR DESCRIPTION

**Prerequisites**:

- [x] Unless it is a hotfix it should be merged against the `dev` branch
- [x] Branch is up-to-date with the branch to be merged with, i.e. `dev`
- [x] Build is successful
- [x] Code is cleaned up and formatted

### Summary

fixes a corner cases when the user is loading state/hrr for the cases/death signal when no data is returned.

e.g., `?date=20210121&region=42003&sensor=indicator-combination-confirmed_7dav_incidence_prop&level=state`