### PR TITLE
Compute offset for tooltip from placement

### DIFF
--- a/src/components/tooltipUtils.js
+++ b/src/components/tooltipUtils.js
@@ -35,7 +35,8 @@ function getOrInitPopper() {
       {
         name: 'offset',
         options: {
-          offset: ({ placement }) => (placement.endsWith('start') ? [8, 8] : [-8, 8]), // [0, 8],
+          // Compute the offset from the placement.
+          offset: ({ placement }) => (placement.endsWith('start') ? [8, 8] : [-8, 8]),
         },
       },
       {

--- a/src/components/tooltipUtils.js
+++ b/src/components/tooltipUtils.js
@@ -35,7 +35,7 @@ function getOrInitPopper() {
       {
         name: 'offset',
         options: {
-          offset: [0, 8],
+          offset: ({ placement }) => (placement.endsWith('start') ? [8, 8] : [-8, 8]), // [0, 8],
         },
       },
       {


### PR DESCRIPTION
closes #739
**Prerequisites**:

- [x] Unless it is a hotfix it should be merged against the `dev` branch
- [x] Branch is up-to-date with the branch to be merged with, i.e. `dev`
- [x] Build is successful
- [x] Code is cleaned up and formatted

### Summary

This change reduces tooltip flickering and improves placement to offset either right or left based on what placement is used (either top-start or top-end, due to the 'flip' option).    

This change also, perhaps coincidentally, substantially reduces the flickering and cut-off issues.  There is still one redraw that is cut-off before it decides to redraw again in flipped mode.
