### PR TITLE
fix: separate between empty region and irrelevant parameter

### DIFF
--- a/src/stores/index.js
+++ b/src/stores/index.js
@@ -392,8 +392,8 @@ export const trackedUrlParams = derived(
         level === DEFAULT_LEVEL
           ? null
           : level,
-      region: mode === modeByID.export || mode === modeByID.timelapse || !region ? null : region,
-      date: mode === modeByID.export || mode === modeByID.landing ? null : date,
+      region: mode === modeByID.export || mode === modeByID.timelapse ? null : region,
+      date: mode === modeByID.export || mode === modeByID.landing ? null : String(date),
       signalC: !inMapMode || !sensorEntry || !sensorEntry.isCasesOrDeath ? null : signalOptions.cumulative,
       signalI: !inMapMode || !sensorEntry || !sensorEntry.isCasesOrDeath ? null : signalOptions.incidence,
       encoding: !inMapMode || encoding === DEFAULT_ENCODING ? null : encoding,


### PR DESCRIPTION
fixes an issue with browser history navigation

**Prerequisites**:

- [x] Unless it is a hotfix it should be merged against the `dev` branch
- [x] Branch is up-to-date with the branch to be merged with, i.e. `dev`
- [x] Build is successful
- [x] Code is cleaned up and formatted

### Summary

to reproduce:
 1. go to https://dev--cmu-delphi-covidcast.netlify.app/overview/?date=20210305
 2. click on a cell, e.g. Montana
 3. click the browser back button

before: the region wasn't cleared

now it is