### PR TITLE
feat: jump back to selected date upon mouseout

### DIFF
--- a/src/modes/mobile/HistoryLineChart.svelte
+++ b/src/modes/mobile/HistoryLineChart.svelte
@@ -9,7 +9,7 @@
     generateLineChartSpec,
     resolveHighlightedDate,
     generateLineAndBarSpec,
-    signalPatches,
+    resetOnClearHighlighTuple,
     MULTI_COLORS,
   } from '../../specs/lineSpec';
   import { toTimeValue } from '../../stores/params';
@@ -217,7 +217,7 @@
   {data}
   tooltip={HistoryLineTooltip}
   tooltipProps={{ sensor }}
-  signals={{ ...signalPatches, highlightRegion }}
+  signals={{ highlight_tuple: resetOnClearHighlighTuple(date.value), highlightRegion }}
   signalListeners={['highlight']}
   on:signal={onSignal}
 />

--- a/src/specs/lineSpec.js
+++ b/src/specs/lineSpec.js
@@ -23,6 +23,16 @@ export function patchHighlightTuple(current) {
   return current;
 }
 
+export function resetOnClearHighlighTuple(date) {
+  return (current) => {
+    patchHighlightTuple(current);
+    const match = /(unit:.*values: )\[/.exec(current.on[0].update);
+    const prefix = match ? match[0] : 'unit: "layer_1", fields: highlight_tuple_fields, values: [';
+    current.on[1].update = `{${prefix}${date.getTime()}]}`;
+    return current;
+  };
+}
+
 export function resolveHighlightedDate(e) {
   const highlighted = e.detail.value;
   if (highlighted && Array.isArray(highlighted.date_value) && highlighted.date_value.length > 0) {
@@ -190,7 +200,7 @@ export function generateLineChartSpec({
               type: 'point',
               on: 'click, mousemove, [touchstart, touchend] > touchmove',
               nearest: true,
-              clear: false,
+              clear: 'view:mouseout',
               encodings: ['x'],
             },
             value: initialDate


### PR DESCRIPTION
**Prerequisites**:

- [x] Unless it is a hotfix it should be merged against the `dev` branch
- [x] Branch is up-to-date with the branch to be merged with, i.e. `dev`
- [x] Build is successful
- [x] Code is cleaned up and formatted

### Summary

to increase consistency this change will jump the highlighted date back to its original position when the user leaves the chart:

![highlight](https://user-images.githubusercontent.com/4129778/111330254-27e3b800-8646-11eb-9edf-78d18aba3597.gif)

cons:
 * you cannot download a picture with a different date