### PR TITLE
fix: reset highlight region in line chart

### DIFF
--- a/src/modes/mobile/HistoryLineChart.svelte
+++ b/src/modes/mobile/HistoryLineChart.svelte
@@ -218,7 +218,7 @@
   let highlightRegion = null;
 
   function highlight(r) {
-    highlightRegion = r ? r.id : null;
+    highlightRegion = r ? r.id : region.value.id;
   }
 
   $: {

--- a/src/specs/mapSpec.js
+++ b/src/specs/mapSpec.js
@@ -404,8 +404,8 @@ export function generateStateSpec(options = {}) {
 
   // state, msa
   spec.layer.push(genLevelLayer(options));
-  spec.layer.push(genCreditsLayer());
   spec.layer.push(genLevelHoverLayer());
+  spec.layer.push(genCreditsLayer());
   return spec;
 }
 
@@ -434,8 +434,8 @@ export function generateNationSpec(options = {}) {
   });
 
   spec.layer.push(genLevelLayer(options));
-  spec.layer.push(genCreditsLayer());
   spec.layer.push(genLevelHoverLayer());
+  spec.layer.push(genCreditsLayer());
   return spec;
 }
 
@@ -453,10 +453,10 @@ export function generateStateMapWithCountyDataSpec(options = {}) {
   spec.datasets.state = stateJSON();
   spec.layer.push(genMegaLayer());
   spec.layer.push(genLevelLayer({ ...options, strokeWidth: 0 }));
-  spec.layer.push(genCreditsLayer());
   spec.layer.push(genStateBorderLayer());
   spec.layer.push(genMegaHoverLayer(true));
   spec.layer.push(genLevelHoverLayer({ strokeWidth: 1 }));
+  spec.layer.push(genCreditsLayer());
   return spec;
 }
 
@@ -502,11 +502,11 @@ export function generateCountiesOfStateSpec(state, { withStates = false, ...opti
     spec.layer[spec.layer.length - 1].transform.unshift(isState);
   }
   spec.layer.push(genLevelLayer(options));
-  spec.layer.push(genCreditsLayer());
   if (withStates) {
     spec.layer.push(genStateBorderLayer());
   }
   spec.layer.push(genLevelHoverLayer());
+  spec.layer.push(genCreditsLayer());
   return spec;
 }
 
@@ -540,7 +540,6 @@ export function generateRelatedCountySpec(county, options = {}) {
   spec.layer.push(genMegaLayer());
   spec.layer.push(genLevelLayer(options));
   spec.layer.push(genStateBorderLayer({ strokeWidth: 2 }));
-  spec.layer.push(genCreditsLayer());
   spec.layer.push(genMegaHoverLayer());
   spec.layer.push(genLevelHoverLayer());
   // highlight the selected one
@@ -556,6 +555,7 @@ export function generateRelatedCountySpec(county, options = {}) {
     },
     value: 1,
   };
+  spec.layer.push(genCreditsLayer());
   return spec;
 }
 


### PR DESCRIPTION
fixes #845, closes #846 , closes #847 

**Prerequisites**:

- [x] Unless it is a hotfix it should be merged against the `dev` branch
- [x] Branch is up-to-date with the branch to be merged with, i.e. `dev`
- [x] Build is successful
- [x] Code is cleaned up and formatted

### Summary

re #845:

![reset_highlight](https://user-images.githubusercontent.com/4129778/111991437-b8107a00-8aea-11eb-812a-2169358e46d5.gif)

re #847

since it is a about a race condition it is difficult to fix. I adapted the code such that only one tooltip content should be visible but I cannot guarantee it.

re #847
![image](https://user-images.githubusercontent.com/4129778/112011831-06c80f00-8aff-11eb-8339-38b465e3e93e.png)
