### PR TITLE
ci: fix update website job by using common ssh key

### DIFF
--- a/.github/workflows/release_main.yml
+++ b/.github/workflows/release_main.yml
@@ -73,6 +73,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: cmu-delphi/www-main
+          ssh-key: ${{ secrets.CMU_DELPHI_DEPLOY_MACHINE_SSH }}
       - uses: actions/setup-node@v2
         with:
           node-version: '14'


### PR DESCRIPTION

**Prerequisites**:

- [x] Unless it is a hotfix it should be merged against the `dev` branch
- [x] Branch is up-to-date with the branch to be merged with, i.e. `dev`
- [x] Build is successful
- [x] Code is cleaned up and formatted

### Summary

try to fix the issue that the release job cannot create a PR in www-main