### PR TITLE
ci: use secret token for cross repo access

### DIFF
--- a/.github/workflows/release_main.yml
+++ b/.github/workflows/release_main.yml
@@ -116,7 +116,7 @@ jobs:
       - name: Create pull request into dev
         uses: peter-evans/create-pull-request@v3
         with:
-          token: ${{ secrets.CMU_DELPHI_DEPLOY_MACHINE_TOKEN }}
+          token: ${{ secrets.CMU_DELPHI_DEPLOY_MACHINE_PAT }}
           branch: bot/sync-main-dev
           commit-message: 'chore: sync main-dev'
           base: dev

--- a/.github/workflows/release_main.yml
+++ b/.github/workflows/release_main.yml
@@ -116,6 +116,7 @@ jobs:
       - name: Create pull request into dev
         uses: peter-evans/create-pull-request@v3
         with:
+          token: ${{ secrets.CMU_DELPHI_DEPLOY_MACHINE_TOKEN }}
           branch: bot/sync-main-dev
           commit-message: 'chore: sync main-dev'
           base: dev


### PR DESCRIPTION
**Prerequisites**:

- [x] Unless it is a hotfix it should be merged against the `dev` branch
- [x] Branch is up-to-date with the branch to be merged with, i.e. `dev`
- [x] Build is successful
- [x] Code is cleaned up and formatted

### Summary

use a personal access token to create the pr in www-main upon release