### PR TITLE
fix: parsing on indicator status dates

### DIFF
--- a/src/data/indicatorInfo.js
+++ b/src/data/indicatorInfo.js
@@ -1,10 +1,8 @@
 // Indicator Info: aka The Signal Dashboard API
 
-import { formatAPITime } from './utils';
+import { formatAPITime, parseAPITime } from './utils';
 import { callSignalAPI } from './api';
 import { fetchData } from './fetchData';
-import { isoParse } from 'd3-time-format';
-import { timeDay } from 'd3-time';
 import { addNameInfos } from '.';
 import { countyInfo } from '../maps';
 
@@ -25,6 +23,10 @@ import { countyInfo } from '../maps';
  * @property {Record<'county', Coverage[]>} coverage
  */
 
+function parseFakeISO(value) {
+  return parseAPITime(value.toString().replace(/-/gm, ''));
+}
+
 /**
  * @returns {Promise<IndicatorStatus[]>}
  */
@@ -35,11 +37,11 @@ export function getIndicatorStatuses() {
     }
     const data = d.epidata || [];
     for (const row of data) {
-      row.latest_issue = timeDay(isoParse(row.latest_issue.toString()));
-      row.latest_time_value = timeDay(isoParse(row.latest_time_value.toString()));
+      row.latest_issue = parseFakeISO(row.latest_issue);
+      row.latest_time_value = parseFakeISO(row.latest_time_value);
       Object.values(row.coverage).forEach((level) => {
         for (const row of level) {
-          row.date = timeDay(isoParse(row.date.toString()));
+          row.date = parseFakeISO(row.date);
           row.fraction = row.count / countyInfo.length;
         }
       });


### PR DESCRIPTION
**Prerequisites**:

- [x] Unless it is a hotfix it should be merged against the `dev` branch
- [x] Branch is up-to-date with the branch to be merged with, i.e. `dev`
- [x] Build is successful
- [x] Code is cleaned up and formatted

### Summary

fix parsing of the indicator status dates to be more like the other dates of the API

before:
![image](https://user-images.githubusercontent.com/4129778/113895706-392c6a00-9797-11eb-9ab6-093d810fa480.png)

after:
![image](https://user-images.githubusercontent.com/4129778/113895724-3e89b480-9797-11eb-9a62-b4d097543dea.png)
