### PR TITLE
fix: mega-counties are not shown

### DIFF
--- a/src/maps/infos.js
+++ b/src/maps/infos.js
@@ -150,8 +150,21 @@ function addInfo(d) {
     infoLookup.set(levelPrefix + key, d);
   }
 }
-nameInfos.forEach(addInfo);
+nameInfos.forEach((d) => addInfo(d));
 addInfo(nationInfo);
+
+megaCountyInfo.forEach((d) => {
+  // find mega counties also by county level
+  const levelPrefix = 'county:';
+  const id = String(d.propertyId).toLowerCase();
+  if (!infoLookup.has(levelPrefix + id)) {
+    infoLookup.set(levelPrefix + id, d);
+  }
+  const key = String(d.id).toLowerCase();
+  if (!infoLookup.has(levelPrefix + key)) {
+    infoLookup.set(levelPrefix + key, d);
+  }
+});
 
 for (const alias of [
   ['02270', '02158'],


### PR DESCRIPTION
**Prerequisites**:

- [x] Unless it is a hotfix it should be merged against the `dev` branch
- [x] Branch is up-to-date with the branch to be merged with, i.e. `dev`
- [x] Build is successful
- [x] Code is cleaned up and formatted

### Summary

fix an issue with the latest version where mega counties are not shown in the map:

before:
![image](https://user-images.githubusercontent.com/4129778/115045172-425abc80-9ea4-11eb-83b5-ec2f018a8011.png)

after: 
![image](https://user-images.githubusercontent.com/4129778/115045067-29520b80-9ea4-11eb-8dd7-de501bcf8eaa.png)
