### PR TITLE
support for neutral indicators

### DIFF
--- a/src/maps/infos.js
+++ b/src/maps/infos.js
@@ -150,8 +150,21 @@ function addInfo(d) {
     infoLookup.set(levelPrefix + key, d);
   }
 }
-nameInfos.forEach(addInfo);
+nameInfos.forEach((d) => addInfo(d));
 addInfo(nationInfo);
+
+megaCountyInfo.forEach((d) => {
+  // find mega counties also by county level
+  const levelPrefix = 'county:';
+  const id = String(d.propertyId).toLowerCase();
+  if (!infoLookup.has(levelPrefix + id)) {
+    infoLookup.set(levelPrefix + id, d);
+  }
+  const key = String(d.id).toLowerCase();
+  if (!infoLookup.has(levelPrefix + key)) {
+    infoLookup.set(levelPrefix + key, d);
+  }
+});
 
 for (const alias of [
   ['02270', '02158'],

--- a/src/modes/mobile/AllIndicatorOverview.svelte
+++ b/src/modes/mobile/AllIndicatorOverview.svelte
@@ -28,18 +28,18 @@
     return Promise.all(sensorList.map((sensor) => fetcher.fetchWindowTrend(sensor, region, date))).then((trends) => {
       const positive = [];
       const negative = [];
-      const unknown = [];
+      const unknownOrNeutral = [];
       trends.forEach((trend, i) => {
-        const inv = sensorList[i].isInverted;
-        if (trend.isIncreasing) {
-          (!inv ? negative : positive).push(sensorList[i]);
-        } else if (trend.isDecreasing) {
-          (inv ? negative : positive).push(sensorList[i]);
+        const sensor = sensorList[i];
+        if (trend.isBetter) {
+          positive.push(sensor);
+        } else if (trend.isWorse) {
+          negative.push(sensor);
         } else {
-          unknown.push(sensorList[i]);
+          unknownOrNeutral.push(sensor);
         }
       });
-      return { positive, negative, unknown };
+      return { positive, negative, unknownOrNeutral };
     });
   }
 
@@ -59,10 +59,10 @@
     are
     <strong>getting better.</strong>
     <AllIndicatorsText sensors={d ? d.negative : null} />
-    {#if d && d.unknown.length > 0}
-      <strong>{d ? d.unknown.length : 'N/A'} of {sensorList.length} indicators</strong>
+    {#if d && d.unknownOrNeutral.length > 0}
+      <strong>{d.unknownOrNeutral.length} of {sensorList.length} indicators</strong>
       are
-      <strong>not available</strong>
+      <strong>have changed</strong> or are <strong>not available</strong>
       for
       {formatDateYearWeekdayAbbr(date.value)}.
     {/if}

--- a/src/modes/mobile/GeoTable.svelte
+++ b/src/modes/mobile/GeoTable.svelte
@@ -68,7 +68,7 @@
       return Promise.resolve([]);
     }
     function toGeoTableRow(r, data, important = false) {
-      const trend = determineTrend(date.value, data, sensor.isInverted);
+      const trend = determineTrend(date.value, data, sensor.highValuesAre);
       return {
         ...r,
         important,

--- a/src/modes/mobile/RegionCountyMap.svelte
+++ b/src/modes/mobile/RegionCountyMap.svelte
@@ -26,7 +26,7 @@
 
   $: spec = generateStateMapWithCountyDataSpec({
     domain: sensor.domain($stats, 'county'),
-    scheme: sensor.vegaColorScale,
+    scheme: sensor.value.vegaColorScale,
   });
   $: data = fetcher.fetch1SensorNRegions1Date(sensor, 'county', '*', date);
 

--- a/src/modes/mobile/RegionCountyMap.svelte
+++ b/src/modes/mobile/RegionCountyMap.svelte
@@ -26,7 +26,7 @@
 
   $: spec = generateStateMapWithCountyDataSpec({
     domain: sensor.domain($stats, 'county'),
-    scheme: sensor.isInverted ? 'yellowgreenblue' : 'yelloworangered',
+    scheme: sensor.vegaColorScale,
   });
   $: data = fetcher.fetch1SensorNRegions1Date(sensor, 'county', '*', date);
 

--- a/src/modes/mobile/RegionHexMap.svelte
+++ b/src/modes/mobile/RegionHexMap.svelte
@@ -11,9 +11,9 @@
   import SensorValue from './SensorValue.svelte';
   import { MISSING_COLOR } from '../../theme';
   import ColorLegend from './components/ColorLegend.svelte';
-  import { hsl } from 'd3-color';
   import DownloadMenu from './components/DownloadMenu.svelte';
   import { formatDateISO } from '../../formats';
+  import { useWhiteTextColor } from '../../util';
 
   export let className = '';
   /**
@@ -92,12 +92,12 @@
 
   function isInvertedColor(v) {
     const color = v && v.value != null ? colorScale(v.value) : MISSING_COLOR;
-    return hsl(color).l < 0.5;
+    return useWhiteTextColor(color);
   }
 
   function style(v) {
     const color = v && v.value != null ? colorScale(v.value) : MISSING_COLOR;
-    const white = hsl(color).l < 0.5;
+    const white = useWhiteTextColor(color);
     return `background-color: ${color}${white ? '; color: white;' : ''}`;
   }
 </script>

--- a/src/modes/mobile/RegionMap.svelte
+++ b/src/modes/mobile/RegionMap.svelte
@@ -32,7 +32,7 @@
     const options = {
       domain: sensor.domain(stats, region.level === 'state' || region.level === 'county' ? 'county' : 'state'),
       withStates: true,
-      scheme: sensor.isInverted ? 'yellowgreenblue' : 'yelloworangered',
+      scheme: sensor.vegaColorScale,
     };
     if (region.level === 'state') {
       return generateCountiesOfStateSpec(region.value, options);

--- a/src/modes/mobile/RegionMap.svelte
+++ b/src/modes/mobile/RegionMap.svelte
@@ -32,7 +32,7 @@
     const options = {
       domain: sensor.domain(stats, region.level === 'state' || region.level === 'county' ? 'county' : 'state'),
       withStates: true,
-      scheme: sensor.vegaColorScale,
+      scheme: sensor.value.vegaColorScale,
     };
     if (region.level === 'state') {
       return generateCountiesOfStateSpec(region.value, options);

--- a/src/modes/mobile/TrendIndicator.svelte
+++ b/src/modes/mobile/TrendIndicator.svelte
@@ -32,6 +32,7 @@
   class:short={!long}
   class:isBetter={trend && trend.isBetter}
   class:isWorse={trend && trend.isWorse}
+  class:isNeutral={trend && trend.isNeutral}
   class:isSteady={trend && trend.isSteady}
   class:block
 >
@@ -90,6 +91,10 @@
   }
   .isBetter {
     --color: #27ae60;
+    --text: white;
+  }
+  .isNeutral {
+    --color: #800080;
     --text: white;
   }
   .isWorse {

--- a/src/modes/mobile/TrendText.svelte
+++ b/src/modes/mobile/TrendText.svelte
@@ -14,4 +14,7 @@
 {:else if trend.isWorse}
   worse by
   {formatFraction(trend.fractionChange)}
+{:else if trend.isNeutral}
+  changed by
+  {formatFraction(trend.fractionChange)}
 {:else}around the same with {formatFraction(trend.fractionChange)}{/if}

--- a/src/modes/mobile/TrendTextSummary.svelte
+++ b/src/modes/mobile/TrendTextSummary.svelte
@@ -38,6 +38,38 @@
     {#if d.isUnknown}
       We don't have data on the historical context for this indicator on
       {formatDateWeekday(date.value, true)}.
+    {:else if d.isNeutral && +date.value === +d.minDate}
+      On
+      {formatDateWeekday(date.value, true)}
+      <strong>{sensor.value.name}</strong>
+      has
+      <strong>
+        <TrendText trend={d.maxTrend} />
+      </strong>
+      compared to the
+      <strong
+        >{WINDOW_SIZE}
+        month maximum value of
+        <SensorValue {sensor} value={d.max ? d.max.value : null} medium /></strong
+      >
+      on
+      <strong>{formatDateYearWeekdayAbbr(d.maxDate, true)}</strong>.
+    {:else if d.isNeutral}
+      On
+      {formatDateWeekday(date.value, true)}
+      <strong>{sensor.value.name}</strong>
+      has
+      <strong>
+        <TrendText trend={d.minTrend} />
+      </strong>
+      compared to the
+      <strong
+        >{WINDOW_SIZE}
+        month minimum value of
+        <SensorValue {sensor} value={d.min ? d.min.value : null} medium /></strong
+      >
+      on
+      <strong>{formatDateYearWeekdayAbbr(d.minDate, true)}</strong>.
     {:else if +date.value === +d.worstDate}
       On
       {formatDateWeekday(date.value, true)}

--- a/src/stores/params.js
+++ b/src/stores/params.js
@@ -466,7 +466,7 @@ export class DataFetcher {
       return this.cache.get(key);
     }
     const trend = this.fetch1Sensor1RegionNDates(sensor, region, date.windowTimeFrame).then((rows) =>
-      determineTrend(date.value, rows, sensor.isInverted),
+      determineTrend(date.value, rows, sensor.highValuesAre),
     );
     this.cache.set(key, trend);
     return trend;
@@ -638,7 +638,7 @@ export class SensorParam {
     this.factor = sensor.format === 'fraction' ? 100 : 1;
     this.isPercentage = sensor.format == 'percent' || sensor.format === 'fraction';
     this.isPer100K = sensor.format === 'per100k';
-    this.isInverted = sensor.isInverted;
+    this.highValuesAre = sensor.highValuesAre;
     this.is7DayAverage = sensor.is7DayAverage;
     this.valueUnit = this.is7DayAverage ? '7-day average' : 'value';
     this.formatValue = formatValue;

--- a/src/stores/questions.js
+++ b/src/stores/questions.js
@@ -135,7 +135,7 @@ function deriveSensor(question) {
     yAxis: descriptions.yAxis,
     format: descriptions.format,
     unit: descriptions.unit,
-    isInverted: descriptions.isInverted,
+    highValuesAre: descriptions.highValuesAre || (descriptions.isInverted === true ? 'good' : 'bad'),
     is7DayAverage: descriptions.is7DayAverage,
     hasStdErr: descriptions.hasStdErr,
     credits: descriptions.credits,

--- a/src/util.js
+++ b/src/util.js
@@ -1,6 +1,26 @@
 import { rgb, hsl } from 'd3-color';
 import ResizeObserver from 'resize-observer-polyfill';
 
+export function useWhiteTextColor(bgColor) {
+  const color = rgb(bgColor);
+
+  function normalizeChannel(channel) {
+    const v = channel / 255;
+    if (v < 0.03928) {
+      return v / 12.92;
+    }
+    return Math.pow((v + 0.055) / 1.055, 2.4);
+  }
+  const r = normalizeChannel(color.r);
+  const g = normalizeChannel(color.g);
+  const b = normalizeChannel(color.b);
+  const relLuminance = 0.2126 * r + 0.7152 * g + 0.0722 * b;
+
+  const blackContrast = (relLuminance + 0.05) / (0.0 + 0.05);
+  const whiteContrast = (1.0 + 0.05) / (relLuminance + 0.05);
+  return blackContrast < whiteContrast;
+}
+
 export function getTextColorBasedOnBackground(bgColor) {
   const color = hsl(bgColor);
   return color.l > 0.32 ? '#000' : '#fff';


### PR DESCRIPTION
closes #902

**Prerequisites**:

- [x] Unless it is a hotfix it should be merged against the `dev` branch
- [x] Branch is up-to-date with the branch to be merged with, i.e. `dev`
- [x] Build is successful
- [x] Code is cleaned up and formatted

### Summary

Note: There are a bunch of changes in https://docs.google.com/document/d/1llv6xh8jMlmVv7WpyDSv4VgUpFAZQ6QjFUeRxxOinmk/edit# and https://docs.google.com/document/d/1J36nedP6eufeRE3TbyT_BK-ofE5d18kLif2UmORkYDU/edit# to better reflect this change. 

However, it should be backwards compatible. 

I locally changed one indicator to be neutral and it would look like:

![image](https://user-images.githubusercontent.com/4129778/115046610-a7fb7880-9ea5-11eb-930e-3d7fbc7789d1.png)
