### PR TITLE
cumulative support for history line charts

### DIFF
--- a/src/blocks/HistoryLineChart.svelte
+++ b/src/blocks/HistoryLineChart.svelte
@@ -13,6 +13,7 @@
     MULTI_COLORS,
     genDateHighlight,
     genAnnotationLayer,
+    generateCumulatedBarSpec,
   } from '../specs/lineSpec';
   import { toTimeValue } from '../data/utils';
   import Toggle from '../components/Toggle.svelte';
@@ -93,9 +94,15 @@
    * @param {import('../../stores/params').RegionParam} region
    * @param {import('../../stores/params').DateParam} date
    * @param {import('../../stores/params').TimeFrame} timeFrame
-   * @param {{height: number, zero: boolean, singleRaw: boolean, isMobile: boolean, singleRegionOnly: boolean}} options
+   * @param {{height: number, zero: boolean, raw: boolean, isMobile: boolean, singleRegionOnly: boolean, cumulated: boolean}} options
    */
-  function genSpec(sensor, region, date, timeFrame, { height, zero, singleRaw, isMobile, singleRegionOnly, domain }) {
+  function genSpec(
+    sensor,
+    region,
+    date,
+    timeFrame,
+    { height, zero, raw, isMobile, singleRegionOnly, domain, cumulated },
+  ) {
     const options = {
       initialDate: highlightDate || date.value,
       height,
@@ -103,11 +110,17 @@
       domain: domain || timeFrame.domain,
       zero,
       xTitle: sensor.xAxis,
-      title: joinTitle([sensor.name, `in ${region.displayName}`], isMobile),
+      title: joinTitle([(cumulated ? 'Cumulated ' : '') + sensor.name, `in ${region.displayName}`], isMobile),
       subTitle: sensor.unit,
       highlightRegion: true,
     };
-    if (singleRaw) {
+    if (cumulated) {
+      options.paddingLeft = 52; // more space for larger numbers
+    }
+    if (raw) {
+      if (cumulated) {
+        return generateCumulatedBarSpec(options);
+      }
       return generateLineAndBarSpec(options);
     }
     if (singleRegionOnly) {
@@ -167,16 +180,33 @@
    * @param {import("../../stores/params").DateParam} date
    * @param {import("../../stores/params").RegionParam} region
    */
-  function loadSingleData(sensor, region, timeFrame) {
+  function loadSingleData(sensor, region, timeFrame, { cumulated }) {
     if (!region.value) {
       return null;
     }
-    const selfData = fetcher.fetch1Sensor1RegionNDates(sensor, region, timeFrame);
+
+    const selfData = fetcher.fetch1Sensor1RegionNDates(sensor.value, region, timeFrame);
     const rawData = fetcher.fetch1Sensor1RegionNDates(sensor.rawValue, region, timeFrame);
 
-    return Promise.all([selfData, rawData]).then((data) => {
-      return combineSignals(data, data[0], ['smoothed', 'raw']);
-    });
+    if (cumulated) {
+      // raw and cumulated
+      const cumulatedData = fetcher.fetch1Sensor1RegionNDates(sensor.rawCumulatedValue, region, timeFrame);
+      return Promise.all([selfData, rawData, cumulatedData]).then((data) => {
+        return combineSignals(
+          data,
+          data[0].map((d) => ({ ...d })),
+          ['smoothed', 'raw', 'cumulated'],
+        );
+      });
+    } else {
+      return Promise.all([selfData, rawData]).then((data) => {
+        return combineSignals(
+          data,
+          data[0].map((d) => ({ ...d })),
+          ['smoothed', 'raw'],
+        );
+      });
+    }
   }
 
   function onSignal(event) {
@@ -207,11 +237,14 @@
    * @param {import("../../stores/params").SensorParam} sensor
    * @param {import("../../stores/params").Region[]} region
    */
-  function generateFileName(sensor, regions, timeFrame, raw) {
+  function generateFileName(sensor, regions, timeFrame, raw, cumulated) {
     const regionName = regions.map((region) => `${region.propertyId}-${region.displayName}`).join(',');
     let suffix = '';
     if (raw) {
       suffix = '_RawVsSmoothed';
+    }
+    if (cumulated) {
+      suffix += '_Cumulated';
     }
     return `${sensor.name}_${regionName}_${formatDateISO(timeFrame.min)}-${formatDateISO(timeFrame.max)}${suffix}`;
   }
@@ -231,24 +264,29 @@
 
   let zoom = false;
   let singleRaw = false;
+  let singleCumulated = false;
 
+  $: raw = singleRaw && sensor.rawValue != null;
+  $: cumulated = raw && singleCumulated && sensor.rawCumulatedValue != null;
   $: regions = raw ? [region.value] : resolveRegions(region.value, singleRegionOnly);
   $: annotations = $annotationManager.getWindowAnnotations(sensor.value, regions, timeFrame.min, timeFrame.max);
-  $: raw = singleRaw && sensor.rawValue != null;
   $: spec = injectRanges(
     genSpec(sensor, region, date, timeFrame, {
       height,
       zero: !zoom,
-      singleRaw: raw,
+      raw,
       isMobile: $isMobileDevice,
       singleRegionOnly,
       domain,
+      cumulated,
     }),
     timeFrame,
     annotations,
   );
-  $: data = raw ? loadSingleData(sensor, region, timeFrame) : loadData(sensor, region, timeFrame, singleRegionOnly);
-  $: fileName = generateFileName(sensor, regions, timeFrame, raw);
+  $: data = raw
+    ? loadSingleData(sensor, region, timeFrame, { cumulated })
+    : loadData(sensor, region, timeFrame, singleRegionOnly);
+  $: fileName = generateFileName(sensor, regions, timeFrame, raw, cumulated);
 
   function findValue(region, data, date, prop = 'value') {
     if (!date) {
@@ -292,15 +330,18 @@
   <Toggle bind:checked={zoom}>Rescale Y-axis</Toggle>
   {#if sensor.rawValue != null}
     <Toggle bind:checked={singleRaw}>Raw Data</Toggle>
+    {#if raw && sensor.rawCumulatedValue != null}
+      <Toggle bind:checked={singleCumulated}>Cumulated Data</Toggle>
+    {/if}
   {/if}
   {#if expandableWindow}
     <Toggle bind:checked={showFull}>Show All Dates</Toggle>
   {/if}
   <div class="spacer" />
-  <DownloadMenu {fileName} {vegaRef} {data} {sensor} {raw} />
+  <DownloadMenu {fileName} {vegaRef} {data} {sensor} {raw} {cumulated} />
 </div>
 
-<div class="{!(singleRaw && sensor.rawValue != null) && regions.length > 1 ? 'mobile-two-col' : ''} legend">
+<div class="{!raw && regions.length > 1 ? 'mobile-two-col' : ''} legend">
   {#each regions as r, i}
     <div
       class="legend-elem"
@@ -324,9 +365,14 @@
         {#await data then d}
           <span class="legend-value">
             <SensorValue {sensor} value={findValue(r, d, highlightDate)} medium />
-            {#if singleRaw && sensor.rawValue != null}
+            {#if raw}
               (raw:
-              <SensorValue {sensor} value={findValue(r, d, highlightDate, 'raw')} medium />)
+              {#if cumulated}
+                <SensorValue {sensor} value={findValue(r, d, highlightDate, 'raw')} medium />, cumulated:
+                <SensorValue {sensor} value={findValue(r, d, highlightDate, 'cumulated')} medium />)
+              {:else}
+                <SensorValue {sensor} value={findValue(r, d, highlightDate, 'raw')} medium />)
+              {/if}
             {/if}
           </span>
         {/await}

--- a/src/components/DownloadMenu.svelte
+++ b/src/components/DownloadMenu.svelte
@@ -19,7 +19,7 @@
   export let sensor = null;
 
   export let raw = false;
-  export let cumulated = false;
+  export let cumulative = false;
 
   export let absolutePos = false;
 
@@ -74,8 +74,8 @@
     if (raw) {
       r.raw = row.raw;
     }
-    if (cumulated) {
-      r.cumulated = row.cumulated;
+    if (cumulative) {
+      r.cumulative = row.cumulative;
     }
     return r;
   }

--- a/src/components/DownloadMenu.svelte
+++ b/src/components/DownloadMenu.svelte
@@ -19,6 +19,7 @@
   export let sensor = null;
 
   export let raw = false;
+  export let cumulated = false;
 
   export let absolutePos = false;
 
@@ -72,6 +73,9 @@
     r.value = row.value;
     if (raw) {
       r.raw = row.raw;
+    }
+    if (cumulated) {
+      r.cumulated = row.cumulated;
     }
     return r;
   }

--- a/src/data/signals.ts
+++ b/src/data/signals.ts
@@ -1,9 +1,9 @@
 export function isCountSignal(signal: string): boolean {
-  return /num/.exec(signal) != null;
+  return signal != null && signal.includes('num');
 }
 
 export function isPropSignal(signal: string): boolean {
-  return /prop/.exec(signal) != null;
+  return signal != null && signal.includes('prop');
 }
 
 export function isDeathSignal(signal: string): boolean {

--- a/src/modes/dashboard/widgets/LineChartWidget.svelte
+++ b/src/modes/dashboard/widgets/LineChartWidget.svelte
@@ -5,7 +5,7 @@
     height: 2,
     zero: true,
     raw: false,
-    cumulated: false,
+    cumulative: false,
   };
 </script>
 
@@ -17,7 +17,7 @@
   import DownloadMenu from '../../../components/DownloadMenu.svelte';
   import {
     generateLineChartSpec,
-    generateCumulatedBarSpec,
+    generateCumulativeBarSpec,
     generateLineAndBarSpec,
     genAnnotationLayer,
     resolveHighlightedDate,
@@ -56,7 +56,7 @@
 
   let zoom = !initialState.zero;
   let singleRaw = initialState.raw;
-  let singleCumulated = initialState.cumulated || false;
+  let singleCumulative = initialState.cumulative || false;
 
   let superState = {};
   $: state = {
@@ -64,7 +64,7 @@
     ...superState,
     zero: !zoom,
     raw: singleRaw,
-    cumulated: singleCumulated,
+    cumulative: singleCumulative,
   };
   $: {
     dispatch('state', { id, state });
@@ -89,9 +89,9 @@
    * @param {import('../../../stores/params').SensorParam} sensor
    * @param {import('../../../stores/params').RegionParam} region
    * @param {import('../../../stores/params').TimeFrame} timeFrame
-   * @param {{zero: boolean, raw: boolean, cumulated: boolean}} options
+   * @param {{zero: boolean, raw: boolean, cumulative: boolean}} options
    */
-  function genSpec(sensor, region, timeFrame, { zero, raw, cumulated }) {
+  function genSpec(sensor, region, timeFrame, { zero, raw, cumulative }) {
     /**
      * @type {import('../../../specs/lineSpec').LineSpecOptions}
      */
@@ -102,7 +102,7 @@
       zero,
       xTitle: sensor.xAxis,
       title: [
-        `${cumulated ? 'Cumulated ' : ''}${sensor.name} in ${region.displayName}`,
+        `${cumulative ? 'Cumulative ' : ''}${sensor.name} in ${region.displayName}`,
         `between ${formatDateYearWeekdayAbbr(timeFrame.min)} and ${formatDateShortWeekdayAbbr(timeFrame.max)}`,
       ],
       subTitle: sensor.unit,
@@ -115,10 +115,10 @@
     const dateTooltip = `' @ ' + cachedTime(datum.date_value, '%a %b %d')`;
     const rawTooltip = `' (raw: ' + cachedNumber(datum.raw, '.1f')`;
     if (raw) {
-      if (cumulated) {
+      if (cumulative) {
         options.paddingLeft = 52; // more space for larger numbers
-        options.infoLabelExpr = `${valueTooltip} ${rawTooltip} + ', cum: ' + cachedNumber(datum.cumulated, '.1f') + ')' + ${dateTooltip}`;
-        return generateCumulatedBarSpec(options);
+        options.infoLabelExpr = `${valueTooltip} ${rawTooltip} + ', cum: ' + cachedNumber(datum.cumulative, '.1f') + ')' + ${dateTooltip}`;
+        return generateCumulativeBarSpec(options);
       }
       options.infoLabelExpr = `${valueTooltip} ${rawTooltip} + ')' + ${dateTooltip}`;
       return generateLineAndBarSpec(options);
@@ -132,9 +132,9 @@
    * @param {import("../../stores/params").DateParam} date
    * @param {import("../../stores/params").TimeFrame} timeFrame
    * @param {boolean} raw
-   * @param {boolean} cumulated
+   * @param {boolean} cumulative
    */
-  function loadData(sensor, region, timeFrame, raw, cumulated) {
+  function loadData(sensor, region, timeFrame, raw, cumulative) {
     const selfData = fetcher.fetch1Sensor1RegionNDates(sensor, region, timeFrame);
 
     if (!raw) {
@@ -142,7 +142,7 @@
     }
 
     const rawData = fetcher.fetch1Sensor1RegionNDates(sensor.rawValue, region, timeFrame);
-    if (!cumulated) {
+    if (!cumulative) {
       return Promise.all([selfData, rawData]).then((data) => {
         return combineSignals(
           data,
@@ -152,13 +152,13 @@
       });
     }
 
-    // raw and cumulated
-    const cumulatedData = fetcher.fetch1Sensor1RegionNDates(sensor.rawCumulatedValue, region, timeFrame);
-    return Promise.all([selfData, rawData, cumulatedData]).then((data) => {
+    // raw and cumulative
+    const cumulativeData = fetcher.fetch1Sensor1RegionNDates(sensor.rawCumulativeValue, region, timeFrame);
+    return Promise.all([selfData, rawData, cumulativeData]).then((data) => {
       return combineSignals(
         data,
         data[0].map((d) => ({ ...d })),
-        ['smoothed', 'raw', 'cumulated'],
+        ['smoothed', 'raw', 'cumulative'],
       );
     });
   }
@@ -167,14 +167,14 @@
    * @param {import("../../stores/params").SensorParam} sensor
    * @param {import("../../stores/params").Region region
    */
-  function generateFileName(sensor, region, timeFrame, raw, cumulated) {
+  function generateFileName(sensor, region, timeFrame, raw, cumulative) {
     const regionName = `${region.propertyId}-${region.displayName}`;
     let suffix = '';
     if (raw) {
       suffix = '_RawVsSmoothed';
     }
-    if (cumulated) {
-      suffix += '_Cumulated';
+    if (cumulative) {
+      suffix += '_Cumulative';
     }
     return `${sensor.name}_${regionName}_${formatDateISO(timeFrame.min)}-${formatDateISO(timeFrame.max)}${suffix}`;
   }
@@ -187,20 +187,20 @@
   }
 
   $: raw = singleRaw && sensor.rawValue != null;
-  $: cumulated = raw && singleCumulated && sensor.rawCumulatedValue != null;
+  $: cumulative = raw && singleCumulative && sensor.rawCumulativeValue != null;
 
   $: annotations = $annotationManager.getWindowAnnotations(sensor.value, region, timeFrame.min, timeFrame.max);
   $: spec = injectRanges(
     genSpec(sensor, region, timeFrame, {
       zero: !zoom,
       raw,
-      cumulated,
+      cumulative,
     }),
     timeFrame,
     annotations,
   );
-  $: data = loadData(sensor, region, timeFrame, raw, cumulated);
-  $: fileName = generateFileName(sensor, region, timeFrame, raw, cumulated);
+  $: data = loadData(sensor, region, timeFrame, raw, cumulative);
+  $: fileName = generateFileName(sensor, region, timeFrame, raw, cumulative);
 
   let vegaRef = null;
 
@@ -269,10 +269,10 @@
     <Toggle bind:checked={zoom} noPadding>Rescale Y-axis</Toggle>
     {#if sensor.rawValue != null}
       <Toggle bind:checked={singleRaw} noPadding>Raw Data</Toggle>
-      {#if raw && sensor.rawCumulatedValue != null}
-        <Toggle bind:checked={singleCumulated}>Cumulated Data</Toggle>
+      {#if raw && sensor.rawCumulativeValue != null}
+        <Toggle bind:checked={singleCumulative}>Cumulative Data</Toggle>
       {/if}
     {/if}
-    <DownloadMenu {fileName} {vegaRef} {data} {sensor} {raw} {cumulated} advanced={false} />
+    <DownloadMenu {fileName} {vegaRef} {data} {sensor} {raw} {cumulative} advanced={false} />
   </svelte:fragment>
 </WidgetCard>

--- a/src/specs/lineSpec.ts
+++ b/src/specs/lineSpec.ts
@@ -478,7 +478,7 @@ export function generateLineAndBarSpec(options: LineSpecOptions = {}): TopLevelS
   return spec;
 }
 
-export function generateCumulatedBarSpec(options: LineSpecOptions = {}): TopLevelSpec {
+export function generateCumulativeBarSpec(options: LineSpecOptions = {}): TopLevelSpec {
   const spec = generateLineChartSpec(options);
   // convert line to bar chart
   const line = spec.layer[0] as NormalizedUnitSpec;
@@ -489,7 +489,7 @@ export function generateCumulatedBarSpec(options: LineSpecOptions = {}): TopLeve
       expr: `floor(width / customCountDays(domain('x')[0], domain('x')[1]))`,
     },
   };
-  (line.encoding!.y as PositionFieldDef<Field>).field = 'cumulated';
+  (line.encoding!.y as PositionFieldDef<Field>).field = 'cumulative';
   (line.encoding!.y as PositionFieldDef<Field>).stack = null;
   (line.encoding!.opacity as PositionValueDef) = {
     value: 0.2,
@@ -498,8 +498,8 @@ export function generateCumulatedBarSpec(options: LineSpecOptions = {}): TopLeve
   const point = spec.layer[1] as NormalizedUnitSpec;
   point.transform = [
     {
-      calculate: `datum.cumulated - datum.raw`,
-      as: 'prevCumulated',
+      calculate: `datum.cumulative - datum.raw`,
+      as: 'prevCumulative',
     },
   ];
   point.mark = {
@@ -509,9 +509,9 @@ export function generateCumulatedBarSpec(options: LineSpecOptions = {}): TopLeve
       expr: `floor(width / customCountDays(domain('x')[0], domain('x')[1]))`,
     },
   };
-  (point.encoding!.y as PositionFieldDef<Field>).field = 'cumulated';
+  (point.encoding!.y as PositionFieldDef<Field>).field = 'cumulative';
   (point.encoding!.y as PositionFieldDef<Field>).stack = null;
-  (point.encoding!.y2 as PositionFieldDef<Field>) = { field: 'prevCumulated' };
+  (point.encoding!.y2 as PositionFieldDef<Field>) = { field: 'prevCumulative' };
   (point.encoding!.opacity as PositionValueDef).value = 1;
 
   return spec;

--- a/src/stores/params.ts
+++ b/src/stores/params.ts
@@ -515,7 +515,7 @@ export class SensorParam {
   readonly signalTooltip: string;
   readonly value: Sensor;
   readonly rawValue?: Sensor;
-  readonly rawCumulatedValue?: Sensor;
+  readonly rawCumulativeValue?: Sensor;
 
   readonly isCasesOrDeath: boolean;
   readonly dataSourceName: string;
@@ -542,7 +542,7 @@ export class SensorParam {
     this.signalTooltip = sensor.signalTooltip;
     this.value = sensor;
     this.rawValue = sensor.rawSensor;
-    this.rawCumulatedValue = sensor.rawCumulatedSensor;
+    this.rawCumulativeValue = sensor.rawCumulativeSensor;
 
     this.isCasesOrDeath = (sensor as SensorEntry).isCasesOrDeath || false;
     this.dataSourceName = sensor.dataSourceName;

--- a/src/stores/params.ts
+++ b/src/stores/params.ts
@@ -515,6 +515,8 @@ export class SensorParam {
   readonly signalTooltip: string;
   readonly value: Sensor;
   readonly rawValue?: Sensor;
+  readonly rawCumulatedValue?: Sensor;
+
   readonly isCasesOrDeath: boolean;
   readonly dataSourceName: string;
 
@@ -540,6 +542,8 @@ export class SensorParam {
     this.signalTooltip = sensor.signalTooltip;
     this.value = sensor;
     this.rawValue = sensor.rawSensor;
+    this.rawCumulatedValue = sensor.rawCumulatedSensor;
+
     this.isCasesOrDeath = (sensor as SensorEntry).isCasesOrDeath || false;
     this.dataSourceName = sensor.dataSourceName;
     this.isPercentage = sensor.format == 'percent' || sensor.format === 'fraction';


### PR DESCRIPTION
**Prerequisites**:

- [x] Unless it is a hotfix it should be merged against the `dev` branch
- [x] Branch is up-to-date with the branch to be merged with, i.e. `dev`
- [x] Build is successful
- [x] Code is cleaned up and formatted

### Summary

add support to show the raw cumulative signal version for cases/deaths. part of #928 

![image](https://user-images.githubusercontent.com/4129778/117993676-ef8eec00-b30d-11eb-8c46-0515ccc9edcc.png)

note: the dark green portion is the amount that has been added for this day
