### PR TITLE
fix: county regions are not found

### DIFF
--- a/src/data/regions.ts
+++ b/src/data/regions.ts
@@ -251,7 +251,7 @@ export function getCountiesOfState(state: RegionInfo): RegionInfo[] {
  * returns the state of a county
  */
 export function getStateOfCounty(county: CountyInfo): RegionInfo | null {
-  if (county.level !== 'county' || county.level !== levelMegaCountyId) {
+  if (county.level !== 'county' && county.level !== levelMegaCountyId) {
     return null;
   }
   return getInfoByName(county.state, 'state')!;

--- a/src/stores/descriptions.raw.txt
+++ b/src/stores/descriptions.raw.txt
@@ -47,7 +47,7 @@ Links:
 ---
 Name: People Wearing Masks
 Id: fb-survey
-Signal: smoothed_wearing_mask_7d
+Signal: smoothed_wwearing_mask_7d
 RawSignal: null
 Type: public
 Levels: [county, msa, state, hrr, nation]
@@ -79,7 +79,7 @@ Links:
 ---
 Name: Vaccine Acceptance
 Id: fb-survey
-Signal: smoothed_covid_vaccinated_or_accept
+Signal: smoothed_wcovid_vaccinated_or_accept
 RawSignal: null
 Type: public
 Levels: [county, msa, state, hrr, nation]
@@ -159,8 +159,8 @@ Links:
 ---
 Name: COVID-Like Symptoms
 Id: fb-survey
-Signal: smoothed_cli
-RawSignal: raw_cli
+Signal: smoothed_wcli
+RawSignal: raw_wcli
 Type: early
 Levels: [county, msa, state, hrr, nation]
 XAxis: Date
@@ -187,8 +187,8 @@ Links:
 ---
 Name: COVID-Like Symptoms in Community
 Id: fb-survey
-Signal: smoothed_hh_cmnty_cli
-RawSignal: raw_hh_cmnty_cli
+Signal: smoothed_whh_cmnty_cli
+RawSignal: raw_whh_cmnty_cli
 Type: early
 Levels: [county, msa, state, hrr, nation]
 XAxis: Date

--- a/src/stores/questions.raw.txt
+++ b/src/stores/questions.raw.txt
@@ -7,7 +7,7 @@ Overview: |
 FullSurveyLink: https://cmu-delphi.github.io/delphi-epidata/symptom-survey/coding.html
 DataAccessLink: https://cmu-delphi.github.io/delphi-epidata/symptom-survey/data-access.html
 ReferenceRawNationSignal: raw_cli
-Waves: [2020-04-06, 2020-04-15, 2020-05-21, 2020-09-08, 2020-11-24, 2020-12-19, 2021-01-12, 2021-02-08, 2021-03-02, 2021-03-02]
+Waves: [2020-04-06, 2020-04-15, 2020-05-21, 2020-09-08, 2020-11-24, 2020-12-19, 2021-01-12, 2021-02-08, 2021-03-02, 2021-03-02, 2021-05-20]
 
 
 # common properties for all questions
@@ -36,8 +36,8 @@ Name: COVID-Like Symptoms
 Category: Symptoms
 Question: |
   In the past 24 hours, have you or anyone in your household experienced a fever, along with cough, shortness of breath, or difficulty breathing?
-Signal: smoothed_cli
-RawSignal: raw_cli
+Signal: smoothed_wcli
+RawSignal: raw_wcli
 SignalTooltip: Estimated proportion of people with COVID-like illness.
 LearnMoreLink: https://cmu-delphi.github.io/delphi-epidata/api/covidcast-signals/fb-survey.html#ili-and-cli-indicators
 AddedInWave: 1
@@ -48,8 +48,8 @@ Name: COVID-Like Symptoms in Community
 Category: Symptoms
 Question: |
   Do you personally know someone in your local community who has COVID-like symptoms?
-Signal: smoothed_hh_cmnty_cli
-RawSignal: raw_hh_cmnty_cli
+Signal: smoothed_whh_cmnty_cli
+RawSignal: raw_whh_cmnty_cli
 SignalTooltip: Estimated proportion of people who know someone who is sick in their local community.
 LearnMoreLink: https://cmu-delphi.github.io/delphi-epidata/api/covidcast-signals/fb-survey.html#ili-and-cli-indicators
 AddedInWave: 1
@@ -60,38 +60,48 @@ Name: Self-Reported Mask Use
 Category: Mask Use
 Question: |
   In the past 7 days, did you wear a mask **most or all of the time** in public?
-Signal: smoothed_wearing_mask_7d
+Signal: smoothed_wwearing_mask_7d
 SignalTooltip: Estimated proportion of people who wore a mask for most or all of the time while in public in the past 7 days; those not in public in the past 7 days are not counted.
 HighValuesAre: good
 LearnMoreLink: https://cmu-delphi.github.io/delphi-epidata/api/covidcast-signals/fb-survey.html#behavior-indicators
 AddedInWave: 8
 OldRevisions:
  - Change: This version asked about the past 5 days instead of 7. This was changed in Wave 8 to match other questions in this survey.
-   Signal: smoothed_wearing_mask
+   Signal: smoothed_wwearing_mask
    AddedInWave: 4
  
 ---
 Name: Other People Wearing Masks
 Category: Mask Use
 Question: |
-  In the past 7 days, when you were in public places where social distancing is not possible, did **most or all other people** wear masks?
-Signal: smoothed_others_masked
-SignalTooltip: Estimated proportion of respondents who say that most or all other people wear masks when they are in public and social distancing is not possible.
+  In the past 7 days, when you were out in public, did **most or all other people** wear masks?
+Signal: smoothed_wothers_masked_public
+SignalTooltip: Estimated proportion of respondents who say that most or all other people wear masks when they are in public.
 HighValuesAre: good
 LearnMoreLink: https://cmu-delphi.github.io/delphi-epidata/api/covidcast-signals/fb-survey.html#behavior-indicators
-AddedInWave: 5
+AddedInWave: 11
+OldRevisions:
+ - Change: This version asked about mask-wearing in public places where social distancing is not possible. This wording was changed in Wave 11.
+   Signal: smoothed_wothers_masked
+   AddedInWave: 5
+
+
 ---
 
 
 Name: COVID Vaccine Acceptance
 Category: Vaccines
 Question: |
-  Have you already received a COVID vaccine, or if a vaccine were offered to you today, would you **definitely** or **probably** choose to get vaccinated?
-Signal: smoothed_covid_vaccinated_or_accept
-SignalTooltip: Estimated proportion of respondents who say that they either have already been vaccinated, or definitely or probably would get vaccinated if a COVID vaccine were offered to them today.
+  Have you already received a COVID vaccine, do you have an appointment to receive a COVID vaccine, or if a vaccine were offered to you today, would you **definitely** or **probably** choose to get vaccinated?
+Signal: smoothed_wcovid_vaccinated_appointment_or_accept
+SignalTooltip: Estimated proportion of respondents who say that they either have already been vaccinated, have an appointment to be vaccinated, or definitely or probably would get vaccinated if a COVID vaccine were offered to them today.
 HighValuesAre: good
 LearnMoreLink: https://cmu-delphi.github.io/delphi-epidata/api/covidcast-signals/fb-survey.html#vaccination-indicators
-AddedInWave: 6
+AddedInWave: 11
+OldRevisions:
+ - Change: This version asked whether respondents received a vaccine or would definitely or probably choose to get vaccinated. Appointments were not included in the calculation because only vaccine-accepting respondents were asked whether they have an appointment to get vaccinated. This was changed in Wave 11 to ask all non-vaccinated respondents whether they have an appointment to get vaccinated.
+   Signal: smoothed_wcovid_vaccinated_or_accept
+   AddedInWave: 6
 
 
 ---
@@ -110,13 +120,13 @@ Name: Went to Essential Store
 Category: Social Distancing
 Question: |
   In the past 24 hours, did you go to an indoor market, grocery store, or pharmacy?
-Signal: smoothed_shop_indoors_1d
+Signal: smoothed_wshop_indoors_1d
 SignalTooltip: Estimated percentage of respondents who went to an “indoor market, grocery store, or pharmacy” in the past 24 hours
 LearnMoreLink: https://cmu-delphi.github.io/delphi-epidata/api/covidcast-signals/fb-survey.html#behavior-indicators
 AddedInWave: 10
 OldRevisions:
  -  Change: This version did not include “indoor” in the prompt. Wave 10 changed this item to focus on indoor activities.
-    Signal: smoothed_shop_1d
+    Signal: smoothed_wshop_1d
     AddedInWave: 4
 
 
@@ -125,7 +135,7 @@ Name: Used Public Transit
 Category: Social Distancing
 Question: |
   In the past 24 hours, did you use public transit?
-Signal: smoothed_public_transit_1d
+Signal: smoothed_wpublic_transit_1d
 SignalTooltip: Estimated proportion of respondents who “used public transit” in the past 24 hours
 LearnMoreLink: https://cmu-delphi.github.io/delphi-epidata/api/covidcast-signals/fb-survey.html#behavior-indicators
 AddedInWave: 4
@@ -136,13 +146,13 @@ Name: Went to Work or School
 Category: Social Distancing
 Question: |
   In the past 24 hours, did you work or go to school indoors outside the place where you are currently staying?
-Signal: smoothed_work_outside_home_indoors_1d
+Signal: smoothed_wwork_outside_home_indoors_1d
 SignalTooltip: Estimated percentage of respondents who worked or went to school indoors and outside their home in the past 24 hours.
 LearnMoreLink: https://cmu-delphi.github.io/delphi-epidata/api/covidcast-signals/fb-survey.html#behavior-indicators
 AddedInWave: 10
 OldRevisions:
  - Change: This version did not include “indoors” in the prompt. Wave 10 changed this item to focus on indoor work and school.
-   Signal: smoothed_work_outside_home_1d
+   Signal: smoothed_wwork_outside_home_1d
    AddedInWave: 4
 
 ---
@@ -150,13 +160,13 @@ Name: Spent Time with Others
 Category: Social Distancing
 Question: |
   In the past 24 hours, did you spend time indoors with someone who isn’t currently staying with you?
-Signal: smoothed_spent_time_indoors_1d
+Signal: smoothed_wspent_time_indoors_1d
 SignalTooltip: Estimated percentage of respondents who “spent time indoors with someone who isn’t currently staying with you” in the past 24 hours 
 LearnMoreLink: https://cmu-delphi.github.io/delphi-epidata/api/covidcast-signals/fb-survey.html#behavior-indicators
 AddedInWave: 10
 OldRevisions:
  - Change: This version did not include “indoors” in the prompt. Wave 10 changed this item to focus on indoor activities.
-   Signal: smoothed_spent_time_1d
+   Signal: smoothed_wspent_time_1d
    AddedInWave: 4
   
 
@@ -166,14 +176,14 @@ Name: Visited Restaurant, Bar, or Cafe
 Category: Social Distancing
 Question: |
   In the past 24 hours, did you have a meal or drink indoors at a bar, restaurant, or cafe?
-Signal: smoothed_restaurant_indoors_1d
+Signal: smoothed_wrestaurant_indoors_1d
 SignalTooltip: Estimated proportion of respondents who had a meal or drink indoors at a “bar, restaurant, or cafe” in the past 24 hours 
 LearnMoreLink: https://cmu-delphi.github.io/delphi-epidata/api/covidcast-signals/fb-survey.html#behavior-indicators
 AddedInWave: 10
 OldRevisions:
  - Change: This version did not include “indoors” in the prompt. Wave 10 changed this item to focus on drinking and dining indoors, rather than take-out or outdoor dining.
    AddedInWave: 4
-   Signal: smoothed_restaurant_1d
+   Signal: smoothed_wrestaurant_1d
 
 ---
 
@@ -182,14 +192,14 @@ Name: Attended Large Event
 Category: Social Distancing
 Question: |
   In the past 24 hours, did you attend an indoor event with more than 10 people?
-Signal: smoothed_large_event_indoors_1d
+Signal: smoothed_wlarge_event_indoors_1d
 SignalTooltip: Estimated percentage of respondents who “attended an indoor event with more than 10 people” in the past 24 hours 
 LearnMoreLink: https://cmu-delphi.github.io/delphi-epidata/api/covidcast-signals/fb-survey.html#behavior-indicators
 AddedInWave: 10
 OldRevisions:
  - Change: This version did not include “indoors” in the prompt. Wave 10 changed this item to focus on indoor events.
    AddedInWave: 4
-   Signal: smoothed_large_event_1d
+   Signal: smoothed_wlarge_event_1d
 
 
 
@@ -198,13 +208,13 @@ Name: Traveled Out of State
 Category: Social Distancing
 Question: |
   In the past 7 days, have you traveled outside of your state?
-Signal: smoothed_travel_outside_state_7d
+Signal: smoothed_wtravel_outside_state_7d
 SignalTooltip: Estimated proportion of respondents who report traveling outside their state in the past 7 days.
 LearnMoreLink: https://cmu-delphi.github.io/delphi-epidata/api/covidcast-signals/fb-survey.html#behavior-indicators
 AddedInWave: 10
 OldRevisions:
  - Change: This version asked about the past 5 days, rather than 7. This was changed in Wave 10 to be consistent with other items on the survey.
-   Signal: smoothed_travel_outside_state_5d
+   Signal: smoothed_wtravel_outside_state_5d
    AddedInWave: 1
  
 
@@ -216,13 +226,13 @@ Name: Felt Anxious
 Category: Mental Health
 Question: |
   In the past 7 days, did you feel anxious **most or all of the time**?
-Signal: smoothed_anxious_7d
+Signal: smoothed_wanxious_7d
 SignalTooltip: Estimated proportion of respondents who reported feeling “nervous, anxious, or on edge” for most or all of the past 7 days
 LearnMoreLink: https://cmu-delphi.github.io/delphi-epidata/api/covidcast-signals/fb-survey.html#mental-health-indicators
 AddedInWave: 10
 OldRevisions:
  - Change: This version asked about the past 5 days, rather than 7. This was changed in Wave 10 to be consistent with other items on the survey.
-   Signal: smoothed_anxious_5d
+   Signal: smoothed_wanxious_5d
    AddedInWave: 4
  
 
@@ -232,13 +242,13 @@ Name: Felt Depressed
 Category: Mental Health
 Question: |
   In the past 7 days, did you feel depressed **most or all of the time**?
-Signal: smoothed_depressed_7d
+Signal: smoothed_wdepressed_7d
 SignalTooltip: Estimated proportion of respondents who reported feeling depressed for most or all of the past 7 days
 LearnMoreLink: https://cmu-delphi.github.io/delphi-epidata/api/covidcast-signals/fb-survey.html#mental-health-indicators
 AddedInWave: 10
 OldRevisions:
  - Change: This version asked about the past 5 days, rather than 7. This was changed in Wave 10 to be consistent with other items on the survey.
-   Signal: smoothed_depressed_5d
+   Signal: smoothed_wdepressed_5d
    AddedInWave: 4
 
 
@@ -247,13 +257,13 @@ Name: Felt Isolated
 Category: Mental Health
 Question: |
   In the past 7 days, did you feel isolated **most or all of the time**?
-Signal: smoothed_felt_isolated_7d
+Signal: smoothed_wfelt_isolated_7d
 SignalTooltip: Estimated proportion of respondents who reported feeling “isolated from others” for most or all of the past 7 days
 LearnMoreLink: https://cmu-delphi.github.io/delphi-epidata/api/covidcast-signals/fb-survey.html#mental-health-indicators
 AddedInWave: 10
 OldRevisions:
  - Change: This version asked about the past 5 days, rather than 7. This was changed in Wave 10 to be consistent with other items on the survey.
-   Signal: smoothed_felt_isolated_5d
+   Signal: smoothed_wfelt_isolated_5d
    AddedInWave: 4
 
 
@@ -264,7 +274,7 @@ Name: Worried About Becoming Sick
 Category: Mental Health
 Question: |
   Do you feel **very or somewhat worried** about becoming seriously ill from COVID-19?
-Signal: smoothed_worried_become_ill
+Signal: smoothed_wworried_become_ill
 SignalTooltip: Estimated proportion of respondents who reported feeling very or somewhat worried that “you or someone in your immediate family might become seriously ill from COVID-19”
 LearnMoreLink: https://cmu-delphi.github.io/delphi-epidata/api/covidcast-signals/fb-survey.html#mental-health-indicators
 AddedInWave: 4
@@ -279,7 +289,7 @@ Name: Worried About Finances
 Category: Mental Health
 Question: |
   Do you feel **very or somewhat worried** about your household’s finances for the next month?
-Signal: smoothed_worried_finances
+Signal: smoothed_wworried_finances
 SignalTooltip: Estimated proportion of respondents who report being very or somewhat worried about their “household’s finances for the next month”
 LearnMoreLink: https://cmu-delphi.github.io/delphi-epidata/api/covidcast-signals/fb-survey.html#mental-health-indicators
 AddedInWave: 4
@@ -294,7 +304,7 @@ Name: Tested in the Last 14 Days
 Category: Testing
 Question: |
   In the past 14 days, did you get tested for COVID-19?
-Signal: smoothed_tested_14d
+Signal: smoothed_wtested_14d
 SignalTooltip: Estimated proportion of people who were tested for COVID-19 in the past 14 days, regardless of their test result
 LearnMoreLink: https://cmu-delphi.github.io/delphi-epidata/api/covidcast-signals/fb-survey.html#testing-indicators
 AddedInWave: 4
@@ -307,7 +317,7 @@ Name: Test Positivity Rate
 Category: Testing
 Question: |
   If you were tested for COVID-19 in the past 14 days, was the test positive?
-Signal: smoothed_tested_positive_14d
+Signal: smoothed_wtested_positive_14d
 SignalTooltip: Estimated test positivity rate (out of 1,000) among people tested for COVID-19 in the past 14 days
 LearnMoreLink: https://cmu-delphi.github.io/delphi-epidata/api/covidcast-signals/fb-survey.html#testing-indicators
 AddedInWave: 4
@@ -320,7 +330,7 @@ Name: Wanted a Test
 Category: Testing
 Question: |
   In the past 14 days, did you want a COVID-19 test but not receive one?
-Signal: smoothed_wanted_test_14d
+Signal: smoothed_wwanted_test_14d
 SignalTooltip: Estimated proportion of people who wanted to be tested for COVID-19 in the past 14 days, out of people who were not tested in that time
 Unit: per 100 people who were not tested
 LearnMoreLink: https://cmu-delphi.github.io/delphi-epidata/api/covidcast-signals/fb-survey.html#testing-indicators


### PR DESCRIPTION
**Prerequisites**:

- [x] Unless it is a hotfix it should be merged against the `dev` branch
- [x] Branch is up-to-date with the branch to be merged with, i.e. `dev`
- [x] Build is successful
- [x] Code is cleaned up and formatted

### Summary

fixes a bug where the state of a region couldn't be resolved

original: 
> On the [dev site](https://dev--cmu-delphi-covidcast.netlify.app/indicator/?date=20210513&sensor=indicator-combination-confirmed_7dav_incidence_prop&region=54007) (but not in the production site), going to "Explore an Indicator", selecting "Cases", then double-clicking on WV, then clicking on one of the counties, creates confusion:  COVIDcast claims that the 1,792,000 population of WV is actually the population of that county, and also that every county hovered over is called "Calhoun County".