### PR TITLE
fix: reused vega spec is not in sync

### DIFF
--- a/src/components/vega/Vega.svelte
+++ b/src/components/vega/Vega.svelte
@@ -221,6 +221,15 @@
         if (!root) {
           return null;
         }
+        if (specDatasetsEntries.length > 0 || loadedData) {
+          // create a shallow copy of spec since we patch it
+          spec = {
+            ...spec,
+            datasets: {
+              ...(spec.datasets || {}),
+            },
+          };
+        }
         // patch in the spec defined datasets with their loaded values
         specDatasetsEntries.forEach((entry, i) => {
           spec.datasets[entry[0]] = ds[i];
@@ -229,7 +238,7 @@
         if (loadedData) {
           // console.log('patch in loaded data');
           patchedInData = loadedData;
-          spec.datasets = { ...(spec.datasets || {}), values: loadedData };
+          spec.datasets.values = loadedData;
         }
         // build vega
         return m.default(root, spec, {


### PR DESCRIPTION
**Prerequisites**:

- [x] Unless it is a hotfix it should be merged against the `dev` branch
- [x] Branch is up-to-date with the branch to be merged with, i.e. `dev`
- [x] Build is successful
- [x] Code is cleaned up and formatted

### Summary

fixes some corner case notable in the indicator dashboard where all line charts look the same

before this fix:

![image](https://user-images.githubusercontent.com/4129778/122358097-9b9ea500-cf54-11eb-9307-f3c3e50b2330.png)
