### PR TITLE
fix dashboard meta update + fix choropleth color pointer

### DIFF
--- a/src/components/SensorBadges.svelte
+++ b/src/components/SensorBadges.svelte
@@ -71,7 +71,8 @@
     color: white;
   }
   .format-badge[data-format='raw'],
-  .format-badge[data-format='raw_count'] {
+  .format-badge[data-format='raw_count'],
+  .format-badge[data-format='count'] {
     background: #6a51a3;
     color: white;
   }

--- a/src/data/api.ts
+++ b/src/data/api.ts
@@ -250,7 +250,7 @@ export interface EpiDataMetaStatsInfo {
 }
 
 export type SignalCategory = 'public' | 'early' | 'late' | 'other';
-export type SignalFormat = 'raw' | 'percent' | 'fraction' | 'per100k' | 'raw_count';
+export type SignalFormat = 'raw' | 'percent' | 'fraction' | 'per100k' | 'count';
 export type SignalHighValuesAre = 'good' | 'bad' | 'neutral';
 
 export interface EpiDataMetaInfo {

--- a/src/data/meta.ts
+++ b/src/data/meta.ts
@@ -174,14 +174,14 @@ function deriveMetaSensors(metadata: EpiDataMetaSourceInfo[]): {
         levels: Object.keys(m.geo_types) as RegionLevel[],
         type: m.category ?? 'other',
         xAxis: m.time_label,
-        yAxis: m.value_label || yAxis[m.format],
-        unit: units[m.format],
+        yAxis: m.value_label || yAxis[m.format] || yAxis.raw,
+        unit: units[m.format] || units.raw,
         colorScale: colorScales[m.high_values_are],
         vegaColorScale: vegaColorScales[m.high_values_are],
         links: sm.link.map((d) => `<a href="${d.href}">${d.alt}</a>`),
         credits: credits,
-        formatValue: formatter[m.format],
-        formatSpecifier: formatSpecifiers[m.format],
+        formatValue: formatter[m.format] || formatter.raw,
+        formatSpecifier: formatSpecifiers[m.format] || formatSpecifiers.raw,
         meta: parsed,
       };
       return s;

--- a/src/data/sensor.ts
+++ b/src/data/sensor.ts
@@ -89,6 +89,7 @@ export const vegaColorScales = {
 export const yAxis = {
   raw: 'arbitrary scale',
   raw_count: 'people',
+  count: 'people',
   percent: 'Percentage',
   per100k: 'per 100,000 people',
   fraction: 'Fraction of population',
@@ -96,6 +97,7 @@ export const yAxis = {
 export const units = {
   raw: 'arbitrary scale',
   raw_count: 'people',
+  count: 'people',
   percent: 'per 100 people',
   per100k: 'per 100,000 people',
   fraction: 'Fraction of population',

--- a/src/formats.ts
+++ b/src/formats.ts
@@ -111,6 +111,7 @@ export function formatRawValue(value?: number | null, enforceSign = false): stri
 export const formatter = {
   raw: formatRawValue,
   raw_count: formatCount,
+  count: formatCount,
   fraction: formatRawValue,
   percent: formatPercentage,
   per100k: formatValue,
@@ -118,6 +119,7 @@ export const formatter = {
 export const formatSpecifiers = {
   raw: ',.2f',
   raw_count: '~s',
+  count: '~s',
   fraction: ',.2f',
   percent: '.2f',
   per100k: ',.1f',

--- a/src/specs/mapSpec.ts
+++ b/src/specs/mapSpec.ts
@@ -337,10 +337,10 @@ function genLevelLegendLayer({ domain }: { domain?: [number, number] }): Normali
           nice: domain == null,
           range: [
             {
-              expr: 'width / 2 - 140',
+              expr: 'width / 2 - 10 - 140',
             },
             {
-              expr: 'width / 2 + 140',
+              expr: 'width / 2 - 10 + 140',
             },
           ],
         },
@@ -364,6 +364,15 @@ function genLevelLegendLayer({ domain }: { domain?: [number, number] }): Normali
           // xOffset: {
           //   expr: 'width / 2',
           // },
+        },
+        encoding: {
+          opacity: {
+            condition: {
+              test: 'datum.value == 0',
+              value: 0,
+            },
+            value: 1,
+          },
         },
       },
       {


### PR DESCRIPTION
closes #973 

**Prerequisites**:

- [x] Unless it is a hotfix it should be merged against the `dev` branch
- [x] Branch is up-to-date with the branch to be merged with, i.e. `dev`
- [x] Build is successful
- [x] Code is cleaned up and formatted

### Summary

fixes the dashboard choropleth color pointer. since 0.0 grey is difficult to add since it would be very small. I just removed the arrow for now. Moreover, I fixed the offset issue for pointing to the wrong value

![image](https://user-images.githubusercontent.com/4129778/126353097-8c71a58e-9a48-4951-b987-057b805277f9.png)
