### PR TITLE
feat: allow lazy evaluation of sensor param for generic pages

### DIFF
--- a/src/modes/dashboard/DashboardParameters.svelte
+++ b/src/modes/dashboard/DashboardParameters.svelte
@@ -3,9 +3,9 @@
   import SensorDatePicker2 from '../../components/SensorDatePicker2.svelte';
   import SensorSearch from '../../components/SensorSearch.svelte';
   import { formatAPITime } from '../../data';
-  import { nationInfo, stateInfo, countyInfo, msaInfo, hrrInfo, hhsInfo } from '../../data/regions';
   import { metaDataManager } from '../../stores';
   import { trackEvent } from '../../stores/ga';
+  import { sortedNameInfos } from './utils';
 
   /**
    * @type {import("../../stores/params").SensorParam}
@@ -44,8 +44,6 @@
     trackEvent('dashboard', 'set_sensor', 'global', d.key);
     sensor.set(d);
   }
-
-  const items = [nationInfo, stateInfo, countyInfo, msaInfo, hrrInfo, hhsInfo].flat();
 </script>
 
 <div class="uk-container content-grid">
@@ -59,7 +57,7 @@
   <RegionSearch
     className="grid-5-9"
     modern
-    {items}
+    items={sortedNameInfos}
     selectedItem={region.value}
     on:change={(e) => setRegion(e.detail && e.detail.level === 'nation' ? null : e.detail)}
   />

--- a/src/modes/dashboard/DashboardParameters.svelte
+++ b/src/modes/dashboard/DashboardParameters.svelte
@@ -3,7 +3,7 @@
   import SensorDatePicker2 from '../../components/SensorDatePicker2.svelte';
   import SensorSearch from '../../components/SensorSearch.svelte';
   import { formatAPITime } from '../../data';
-  import { nameInfos } from '../../data/regions';
+  import { nationInfo, stateInfo, countyInfo, msaInfo, hrrInfo, hhsInfo } from '../../data/regions';
   import { metaDataManager } from '../../stores';
   import { trackEvent } from '../../stores/ga';
 
@@ -44,6 +44,8 @@
     trackEvent('dashboard', 'set_sensor', 'global', d.key);
     sensor.set(d);
   }
+
+  const items = [nationInfo, stateInfo, countyInfo, msaInfo, hrrInfo, hhsInfo].flat();
 </script>
 
 <div class="uk-container content-grid">
@@ -57,7 +59,7 @@
   <RegionSearch
     className="grid-5-9"
     modern
-    items={nameInfos}
+    {items}
     selectedItem={region.value}
     on:change={(e) => setRegion(e.detail && e.detail.level === 'nation' ? null : e.detail)}
   />

--- a/src/modes/dashboard/config/RegionPicker.svelte
+++ b/src/modes/dashboard/config/RegionPicker.svelte
@@ -1,6 +1,7 @@
 <script>
   import RegionSearch from '../../../components/RegionSearch.svelte';
-  import { countyInfo, getInfoByName, hhsInfo, hrrInfo, msaInfo, nationInfo, stateInfo } from '../../../data/regions';
+  import { getInfoByName } from '../../../data/regions';
+  import { sortedNameInfos } from '../utils';
 
   /**
    * @type {import("../../../stores/params").RegionParam}
@@ -15,7 +16,7 @@
     id: '',
     displayName: `Use Configured: ${region.displayName}`,
   };
-  $: allItems = [defaultRegion, nationInfo, ...stateInfo, ...msaInfo, ...countyInfo, ...hrrInfo, ...hhsInfo];
+  $: allItems = [defaultRegion, ...sortedNameInfos];
 </script>
 
 <div>

--- a/src/modes/dashboard/utils.ts
+++ b/src/modes/dashboard/utils.ts
@@ -1,3 +1,5 @@
+import { countyInfo, hhsInfo, hrrInfo, msaInfo, nationInfo, stateInfo } from '../../data/regions';
+
 export function formToConfig(formData: FormData): Record<string, unknown> {
   const config: Record<string, unknown> = {};
 
@@ -30,3 +32,5 @@ export function formToConfig(formData: FormData): Record<string, unknown> {
   });
   return config;
 }
+
+export const sortedNameInfos = [nationInfo, ...stateInfo, ...msaInfo, ...countyInfo, ...hrrInfo, ...hhsInfo];

--- a/src/modes/index.ts
+++ b/src/modes/index.ts
@@ -8,6 +8,7 @@ export interface Mode {
   component: () => Promise<any>;
   anchor?: string;
   waitForReady?: boolean;
+  isGeneric?: boolean;
 }
 
 export default modes;

--- a/src/modes/modes.js
+++ b/src/modes/modes.js
@@ -33,11 +33,13 @@ export const modes = [
   {
     id: 'export',
     label: 'Export Data',
+    isGeneric: true,
     component: () => import(/* webpackChunkName: 'm-export' */ './exportdata/ExportData.svelte').then((r) => r.default),
   },
   {
     id: 'indicator-status',
     label: 'Indicator Status Overview',
+    isGeneric: true,
     component: () =>
       import(/* webpackChunkName: 'm-indicator-status' */ './indicator-status/IndicatorStatusOverview.svelte').then(
         (r) => r.default,
@@ -47,6 +49,7 @@ export const modes = [
   {
     id: 'indicator-source',
     label: 'Indicator Source',
+    isGeneric: true,
     component: () =>
       import(/* webpackChunkName: 'm-indicator-source' */ './indicator-status/IndicatorSource.svelte').then(
         (r) => r.default,
@@ -56,6 +59,7 @@ export const modes = [
   {
     id: 'indicator-signal',
     label: 'Indicator Signal',
+    isGeneric: true,
     component: () =>
       import(/* webpackChunkName: 'm-indicator-signal' */ './indicator-status/IndicatorSignal.svelte').then(
         (r) => r.default,
@@ -65,6 +69,7 @@ export const modes = [
   {
     id: 'dashboard',
     label: 'Dashboard Builder',
+    isGeneric: true,
     component: () =>
       import(/* webpackChunkName: 'm-dashboard' */ './dashboard/Dashboard.svelte').then((r) => r.default),
     waitForReady: true,


### PR DESCRIPTION
**Prerequisites**:

- [x] Unless it is a hotfix it should be merged against the `dev` branch
- [x] Branch is up-to-date with the branch to be merged with, i.e. `dev`
- [x] Build is successful
- [x] Code is cleaned up and formatted

### Summary

fixes when the dashboard is opened with a non-standard signal (e.g., `/dashboard/?date=20210814&sensor=fb-survey-raw_ili`) that it would resolve to a default signal. 

Also improves the order of the dashboard builder region search by ordering results by type instead purely by name