### PR TITLE
Remove 'per 100' for percentages

### DIFF
--- a/src/data/sensor.ts
+++ b/src/data/sensor.ts
@@ -100,7 +100,7 @@ export const units = {
   raw: 'arbitrary scale',
   raw_count: 'people',
   count: 'people',
-  percent: '',
+  percent: 'percent',
   per100k: 'per 100,000 people',
   fraction: 'Fraction of population',
 };

--- a/src/data/sensor.ts
+++ b/src/data/sensor.ts
@@ -100,7 +100,7 @@ export const units = {
   raw: 'arbitrary scale',
   raw_count: 'people',
   count: 'people',
-  percent: 'per 100 people',
+  percent: '',
   per100k: 'per 100,000 people',
   fraction: 'Fraction of population',
 };

--- a/src/stores/params.ts
+++ b/src/stores/params.ts
@@ -130,7 +130,7 @@ export class SensorParam {
     this.valueUnit = this.is7DayAverage ? '7-day average' : 'value';
     this.formatValue = (v, e) => sensor.formatValue(v, e);
     this.unit = sensor.unit;
-    this.unitShort = this.isPer100K ? 'per 100k' : this.isPercentage ? '' : this.unit;
+    this.unitShort = this.isPer100K ? 'per 100k' : this.unit;
     this.unitHTML = this.isPer100K
       ? `<span class="per100k"><span>PER</span><span>100K</span></span>`
       : this.isPercentage

--- a/src/stores/params.ts
+++ b/src/stores/params.ts
@@ -130,7 +130,7 @@ export class SensorParam {
     this.valueUnit = this.is7DayAverage ? '7-day average' : 'value';
     this.formatValue = (v, e) => sensor.formatValue(v, e);
     this.unit = sensor.unit;
-    this.unitShort = this.isPer100K ? 'per 100k' : this.isPercentage ? 'per 100' : this.unit;
+    this.unitShort = this.isPer100K ? 'per 100k' : this.isPercentage ? '' : this.unit;
     this.unitHTML = this.isPer100K
       ? `<span class="per100k"><span>PER</span><span>100K</span></span>`
       : this.isPercentage


### PR DESCRIPTION
closes #1008 

**Prerequisites**:

- [x] Unless it is a hotfix it should be merged against the `dev` branch
- [x] Branch is up-to-date with the branch to be merged with, i.e. `dev`
- [x] Build is successful
- [ ] Code is cleaned up and formatted

### Summary

Drop "per 100" "per 100 people" for percentages. The % is sufficient.
