### PR TITLE
style: add hint to sparklines about start ends

### DIFF
--- a/src/blocks/IndicatorOverview.svelte
+++ b/src/blocks/IndicatorOverview.svelte
@@ -92,4 +92,22 @@
     line-height: 1;
     font-size: 0.75rem;
   }
+  .date-range > span {
+    position: relative;
+    padding: 0 2px;
+  }
+  .date-range > span::before {
+    content: '';
+    position: absolute;
+    left: 0;
+    top: -3px;
+    height: 4px;
+    background: black;
+    width: 1px;
+  }
+
+  .date-range > span:last-of-type::before {
+    left: unset;
+    right: 0;
+  }
 </style>


### PR DESCRIPTION
closes #1022 

**Prerequisites**:

- [x] Unless it is a hotfix it should be merged against the `dev` branch
- [x] Branch is up-to-date with the branch to be merged with, i.e. `dev`
- [x] Build is successful
- [x] Code is cleaned up and formatted

### Summary

add small indicators to sparklines to better indicate what the start and end date are:

![image](https://user-images.githubusercontent.com/4129778/135729349-b46a77d6-084f-45bf-880b-14dbc9b7ffd4.png)
