### PR TITLE
show latest available data in indicator table

### DIFF
--- a/src/components/KPIChange.svelte
+++ b/src/components/KPIChange.svelte
@@ -11,7 +11,7 @@
   $: scaled = value != null && !Number.isNaN(value) ? value * 100 : null;
 
   $: base = loading ? '00' : scaled == null ? 'N/A' : Math.floor(scaled);
-  $: fraction = !loading ? Math.round(Math.abs(scaled)) % 100 : 0;
+  $: fraction = !loading ? Math.round(Math.abs(scaled) * 100) % 100 : 0;
 </script>
 
 <KPI text={sign(base, (v) => v.toLocaleString(), true)} sub={`.${fraction}%`} {loading} />

--- a/src/components/SensorDatePicker2.svelte
+++ b/src/components/SensorDatePicker2.svelte
@@ -6,6 +6,7 @@
   import { metaDataManager } from '../stores';
   import { formatDateShortDayOfWeekAbbr, formatDateYearDayOfWeekAbbr, formatWeek } from '../formats';
   import { timeDay } from 'd3-time';
+  import { yesterdayDate } from '../data/TimeFrame';
 
   /**
    * @type {import('../stores/constants').Sensor}
@@ -38,14 +39,14 @@
       offset={11}
       bind:selected={value}
       start={timeFrame.min}
-      end={timeFrame.max}
+      end={yesterdayDate}
       pickWeek={sensor.isWeeklySignal}
       formattedSelected={sensor.isWeeklySignal ? formatWeek(value) : formatDateShortDayOfWeekAbbr(value)}
     >
       <button
         aria-label="selected date"
         class="selected-date picker-button"
-        on:dblclick={() => (value = timeFrame.max)}
+        on:dblclick={() => (value = yesterdayDate)}
         on:
       >
         <span class="selected-date-icon">
@@ -84,7 +85,7 @@
   <button
     class="arrow-button picker-button arrow-right"
     title="Go to the next {sensor.isWeeklySignal ? 'week' : 'day'}"
-    disabled={value == null || value >= timeFrame.max}
+    disabled={value == null || value >= yesterdayDate}
     on:click={() => (value = timeDay.offset(value, sensor.isWeeklySignal ? 7 : 1))}
   >
     {@html arrowRightIcon}


### PR DESCRIPTION
closes #1057, closes #1075

**Prerequisites**:

- [x] Unless it is a hotfix it should be merged against the `dev` branch
- [x] Branch is up-to-date with the branch to be merged with, i.e. `dev`
- [x] Build is successful
- [x] Code is cleaned up and formatted

### Summary

show the latest available data within the sparkline time frame:

![image](https://user-images.githubusercontent.com/4129778/143285341-a0023fa4-a693-4bd2-9375-d6e22166bf11.png)
