### PR TITLE
add temporary custom annotation for uncertainty

### DIFF
--- a/src/blocks/HistoryLineChart.svelte
+++ b/src/blocks/HistoryLineChart.svelte
@@ -9,6 +9,7 @@
     generateLineChartSpec,
     resolveHighlightedDate,
     generateLineAndBarSpec,
+    genUncertaintyLayer,
     resetOnClearHighlighTuple,
     MULTI_COLORS,
     genDateHighlight,
@@ -53,8 +54,6 @@
    * @type {Date|null}
    */
   export let ends = null;
-
-  export let showAnnotations = true;
 
   export let showNeighbors = true;
 
@@ -252,6 +251,10 @@
     if (ends && ends < timeFrame.max) {
       spec.layer.unshift(genDateHighlight(ends < timeFrame.min ? timeFrame.min : ends));
     }
+    const uncertaintyAnnotation = annotations.find((d) => d.uncertainty);
+    if (uncertaintyAnnotation) {
+      spec.layer.push(genUncertaintyLayer(uncertaintyAnnotation, { color }));
+    }
     return spec;
   }
 
@@ -261,9 +264,7 @@
 
   $: raw = singleRaw && sensor.rawValue != null && !($isMobileDevice && showFull);
   $: regions = raw ? [region.value] : resolveRegions(region.value, singleRegionOnly, showNeighbors);
-  $: annotations = showAnnotations
-    ? $annotationManager.getWindowAnnotations(sensor.value, regions, timeFrame.min, timeFrame.max)
-    : [];
+  $: annotations = $annotationManager.getWindowAnnotations(sensor.value, regions, timeFrame.min, timeFrame.max, true);
   $: spec = injectRanges(
     genSpec(sensor, region, date, timeFrame, {
       height,

--- a/src/components/IndicatorAnnotation.svelte
+++ b/src/components/IndicatorAnnotation.svelte
@@ -1,16 +1,21 @@
 <script>
   import warningIcon from '!raw-loader!@fortawesome/fontawesome-free/svgs/solid/exclamation-triangle.svg';
+  import infoIcon from '!raw-loader!@fortawesome/fontawesome-free/svgs/solid/info-circle.svg';
   import { formatDateISO } from '../formats';
 
   export let className = '';
   export let annotation;
 </script>
 
-<div class="uk-alert uk-alert-warning {className}">
+<div class="uk-alert uk-alert-{annotation.uncertainty ? 'info' : 'warning'} {className}">
   <h5 class="alert-header">
     <div class="text">
       <span class="inline-svg-icon">
-        {@html warningIcon}
+        {#if annotation.uncertainty}
+          {@html infoIcon}
+        {:else}
+          {@html warningIcon}
+        {/if}
       </span>
       {annotation.problem}
     </div>

--- a/src/data/api.ts
+++ b/src/data/api.ts
@@ -333,20 +333,8 @@ export interface EpiDataAnomaliesRow {
 export function callAnomaliesAPI(): Promise<EpiDataAnomaliesRow[]> {
   const url = new URL(ENDPOINT + '/covidcast/anomalies');
   url.searchParams.set('format', 'json');
-  const data = fetchImpl<EpiDataAnomaliesRow[]>(url).catch((error) => {
+  return fetchImpl<EpiDataAnomaliesRow[]>(url).catch((error) => {
     console.warn('failed fetching data', error);
     return [] as EpiDataAnomaliesRow[];
-  });
-
-  return data.then((rows) => {
-    rows.push({
-      dates: '-10',
-      explanation: 'This is an informative description text what is going on',
-      problem: 'Informative Description',
-      regions: 'nation(*);state(*);county(*);hrr(*)',
-      source: 'doctor-visits',
-      signals: 'smoothed_adj_cli',
-    });
-    return rows;
   });
 }

--- a/src/data/api.ts
+++ b/src/data/api.ts
@@ -325,7 +325,7 @@ export interface EpiDataAnomaliesRow {
   explanation: string;
   source: string;
   signals: string; // * or a comma separated list "*"|(ID{\s*";"\s*ID}*)
-  dates: string; // YYYYMMDD-YYYYMMDD
+  dates: string; // YYYYMMDD-YYYYMMDD or -99 uncertainty days
   regions: string; //semicolor separated key value: e.g. GROUP("*"|(ID{","\s*ID}*)){\s*","\s*GROUP("*"|(ID{","\s*ID}*))}
   reference?: string;
 }
@@ -333,8 +333,20 @@ export interface EpiDataAnomaliesRow {
 export function callAnomaliesAPI(): Promise<EpiDataAnomaliesRow[]> {
   const url = new URL(ENDPOINT + '/covidcast/anomalies');
   url.searchParams.set('format', 'json');
-  return fetchImpl<EpiDataAnomaliesRow[]>(url).catch((error) => {
+  const data = fetchImpl<EpiDataAnomaliesRow[]>(url).catch((error) => {
     console.warn('failed fetching data', error);
-    return [];
+    return [] as EpiDataAnomaliesRow[];
+  });
+
+  return data.then((rows) => {
+    rows.push({
+      dates: '-10',
+      explanation: 'This is an informative description text what is going on',
+      problem: 'Informative Description',
+      regions: 'nation(*);state(*);county(*);hrr(*)',
+      source: 'doctor-visits',
+      signals: 'smoothed_adj_cli',
+    });
+    return rows;
   });
 }

--- a/src/specs/lineSpec.ts
+++ b/src/specs/lineSpec.ts
@@ -169,10 +169,10 @@ export function genAnnotationLayer(
           text:
             annotations.length > 1
               ? {
-                  expr: `(datum.uncertainty ? '🛈' : '⚠') + ' (' + (datum.index + 1) + ')'`,
+                  expr: `(datum.uncertainty ? 'ℹ️' : '⚠') + ' (' + (datum.index + 1) + ')'`,
                 }
               : {
-                  expr: `datum.uncertainty ? '🛈' : '⚠'`,
+                  expr: `datum.uncertainty ? 'ℹ️' : '⚠'`,
                 },
           baseline: 'top',
           align: 'left',

--- a/src/specs/lineSpec.ts
+++ b/src/specs/lineSpec.ts
@@ -5,6 +5,7 @@ import type { LayerSpec, NormalizedLayerSpec, NormalizedUnitSpec, TopLevelSpec }
 import { CURRENT_DATE_HIGHLIGHT } from '../components/vega/vegaSpecUtils';
 import type { Annotation } from '../data';
 import type { RegionInfo } from '../data/regions';
+import { toTimeValue } from '../data/utils';
 import { BASE_SPEC, commonConfig, CREDIT } from './commonSpec';
 
 // dark2
@@ -132,6 +133,7 @@ export function genAnnotationLayer(
     data: {
       values: annotations.map((a, i) => ({
         index: i,
+        uncertainty: a.uncertainty,
         start: a.dates[0] < dataDomain.min ? dataDomain.min : a.dates[0],
         end: a.dates[1] > dataDomain.max ? dataDomain.max : a.dates[1],
       })),
@@ -142,7 +144,6 @@ export function genAnnotationLayer(
           type: 'rect',
           tooltip: false,
           opacity: 0.1,
-          color: '#D46B08',
         },
         encoding: {
           x: {
@@ -153,18 +154,26 @@ export function genAnnotationLayer(
             field: 'end',
             type: 'temporal',
           },
+          color: {
+            condition: {
+              test: 'datum.uncertainty',
+              value: '#767676',
+            },
+            value: '#D46B08',
+          },
         },
       },
       {
         mark: {
           type: 'text',
-          color: '#D46B08',
           text:
             annotations.length > 1
               ? {
-                  expr: `'⚠ (' + (datum.index + 1) + ')'`,
+                  expr: `(datum.uncertainty ? '🛈' : '⚠') + ' (' + (datum.index + 1) + ')'`,
                 }
-              : '⚠',
+              : {
+                  expr: `datum.uncertainty ? '🛈' : '⚠'`,
+                },
           baseline: 'top',
           align: 'left',
           dx: 2,
@@ -178,9 +187,54 @@ export function genAnnotationLayer(
           y: {
             value: 0,
           },
+          color: {
+            condition: {
+              test: 'datum.uncertainty',
+              value: '#767676',
+            },
+            value: '#D46B08',
+          },
         },
       },
     ],
+  };
+}
+
+export function genUncertaintyLayer(
+  annotation: Annotation,
+  {
+    dateField = 'date_value',
+    valueField = 'value',
+  }: {
+    dateField?: string;
+    valueField?: string;
+  },
+): NormalizedUnitSpec {
+  const start = toTimeValue(annotation.dates[0]);
+  const end = toTimeValue(annotation.dates[1]);
+
+  return {
+    transform: [
+      {
+        filter: `datum.time_value >= ${start} && datum.time_value <= ${end}`,
+      },
+    ],
+    mark: {
+      type: 'line',
+      color: 'white',
+      point: false,
+      strokeDash: [2, 2],
+    },
+    encoding: {
+      x: {
+        field: dateField,
+        type: 'temporal',
+      },
+      y: {
+        field: valueField,
+        type: 'quantitative',
+      },
+    },
   };
 }
 


### PR DESCRIPTION
closes #1050 

**Prerequisites**:

- [x] Unless it is a hotfix it should be merged against the `dev` branch
- [x] Branch is up-to-date with the branch to be merged with, i.e. `dev`
- [x] Build is successful
- [x] Code is cleaned up and formatted

### Summary

first version of showing an uncertainty annotation in the line chart:

![image](https://user-images.githubusercontent.com/4129778/143300914-84b0a1d2-89dd-4038-bd31-9f96e6e1243f.png)

Note

for now implemented as an annotation that can be later one moved to data anomalies sheet used by the delphi-epidata server. However, it will use a new syntax which is not compatible to the current versions deployed. Thus, we test this version here, remove the temporary annotation, and then once deployed readd the annotation to the sheet