### PR TITLE
Add inactive source toggle

### DIFF
--- a/src/modes/exportdata/ExportData.svelte
+++ b/src/modes/exportdata/ExportData.svelte
@@ -44,6 +44,8 @@
 
   $: sensorLevels = sensor ? $metaDataManager.getLevels(sensor) : null;
 
+  $: showInActive = false;
+
   $: {
     if (sensorLevels && !sensorLevels.includes(geoType)) {
       // reset to a valid one
@@ -178,10 +180,13 @@
             <div class="uk-form-controls">
               <select id="ds" bind:value={sourceValue} size="8" class="uk-select">
                 {#each $metaDataManager.metaSources as source}
-                  <option value={source.source}>{source.name}</option>
+                  {#if showInActive || source.signals.some((d) => d.active)}
+                    <option value={source.source}>{source.name}</option>
+                  {/if}
                 {/each}
               </select>
             </div>
+            <label><input type="checkbox" bind:checked={showInActive} />Show Inactive Signals</label>
           </div>
         </div>
 


### PR DESCRIPTION
closes #1118 

**Prerequisites**:

- [x] Unless it is a hotfix it should be merged against the `dev` branch
- [x] Branch is up-to-date with the branch to be merged with, i.e. `dev`
- [x] Build is successful
- [x] Code is cleaned up and formatted

### Summary

hide data sources with no "active" signals by default: 

![image](https://user-images.githubusercontent.com/4129778/148466626-a4a3e057-e3fa-44b4-995d-d4676fe0c960.png)
