### PR TITLE
load "latest" of full time frame

### DIFF
--- a/src/blocks/HistoryLineChart.svelte
+++ b/src/blocks/HistoryLineChart.svelte
@@ -26,6 +26,7 @@
   import IndicatorAnnotations from '../components/IndicatorAnnotations.svelte';
   import { joinTitle } from '../specs/commonSpec';
   import { TimeFrame } from '../stores/params';
+  import { timeDay } from 'd3-time';
 
   export let height = 250;
 
@@ -88,7 +89,9 @@
   };
 
   function mixTimeFrame(st, dw) {
-    if (st.max < dw.max) {
+    const diff = timeDay.count(st.max, dw.max);
+    if (diff >= 0 && diff <= 2) {
+      // use the "latest"
       return new TimeFrame(st.min, dw.max, st.min_week, dw.max_week);
     }
     return st;

--- a/src/blocks/HistoryLineChart.svelte
+++ b/src/blocks/HistoryLineChart.svelte
@@ -25,6 +25,7 @@
   import IndicatorAnnotation from '../components/IndicatorAnnotation.svelte';
   import IndicatorAnnotations from '../components/IndicatorAnnotations.svelte';
   import { joinTitle } from '../specs/commonSpec';
+  import { TimeFrame } from '../stores/params';
 
   export let height = 250;
 
@@ -86,9 +87,16 @@
     displayName: 'Neighboring Counties',
   };
 
+  function mixTimeFrame(st, dw) {
+    if (st.max < dw.max) {
+      return new TimeFrame(st.min, dw.max, st.min_week, dw.max_week);
+    }
+    return st;
+  }
+
   $: highlightDate = date.value;
   $: showAllDates = showFull && !($isMobileDevice && raw);
-  $: timeFrame = showAllDates ? sensor.timeFrame : date.windowTimeFrame;
+  $: timeFrame = showAllDates ? mixTimeFrame(sensor.timeFrame, date.windowTimeFrame) : date.windowTimeFrame;
 
   /**
    * @param {import('../stores/params').SensorParam} sensor

--- a/src/blocks/MaxDateHint.svelte
+++ b/src/blocks/MaxDateHint.svelte
@@ -9,13 +9,47 @@
 
   export let suffix = '';
 
+  /**
+   * @type {import("../../stores/params").DateParam | null}
+   */
+  export let date = null;
+  /**
+   * @type {import("../../stores/params").RegionParam | null}
+   */
+  export let region = null;
+  /**
+   * @type {import("../../stores/DataFetcher").DataFetcher | null}
+   */
+  export let fetcher = null;
+
+  let maxTime;
   $: info = $metaDataManager.getMetaData(sensor);
+
+  function updateMaxTime(fetcher, sensor, region, date) {
+    if (date.sparkLineTimeFrame.max <= maxTime) {
+      return;
+    }
+    const sparkline = fetcher.fetch1Sensor1RegionSparkline(sensor, region, date);
+    // use sparkline data to find the "real" max time
+    sparkline.then((data) => {
+      const maxDate = data.reduce((acc, v) => (v.date_value > acc ? v.date_value : acc), maxTime);
+      if (maxDate > maxTime) {
+        maxTime = maxDate;
+      }
+    });
+  }
+  $: {
+    maxTime = info.maxTime;
+    if (fetcher && region && date) {
+      updateMaxTime(fetcher, sensor, region, date);
+    }
+  }
 </script>
 
 {#if info}
   <UIKitHint
     title="Most recent available date:<br>&nbsp;{formatDateYearDayOfWeekAbbr(
-      info.maxTime,
+      maxTime,
     )}<br>Last update on:<br>&nbsp;{formatDateYearDayOfWeekAbbr(info.maxIssue)}"
     noMargin={suffix.length > 0}
     inline={suffix.length === 0}

--- a/src/modes/indicator/Indicator.svelte
+++ b/src/modes/indicator/Indicator.svelte
@@ -72,7 +72,7 @@
 
       <p>
         On {formatDateDayOfWeek(date.value)}
-        <MaxDateHint sensor={sensor.value} suffix="," />
+        <MaxDateHint sensor={sensor.value} suffix="," {date} {region} {fetcher} />
         the {sensor.valueUnit} was:
       </p>
       <IndicatorOverview {sensor} {date} {region} {fetcher} />

--- a/src/modes/summary/CasesOverview.svelte
+++ b/src/modes/summary/CasesOverview.svelte
@@ -37,7 +37,7 @@
 
 <p>
   On {formatDateDayOfWeek(date.value)}
-  <MaxDateHint sensor={CASES.value} suffix="," />
+  <MaxDateHint sensor={CASES.value} suffix="," {date} {region} {fetcher} />
   the {CASES.valueUnit}s were:
 </p>
 

--- a/src/modes/survey-results/SurveyQuestion.svelte
+++ b/src/modes/survey-results/SurveyQuestion.svelte
@@ -118,7 +118,7 @@
     <p>
       On
       {formatDateYearDayOfWeekAbbr(date.value, true)}
-      <MaxDateHint sensor={sensor.value} />
+      <MaxDateHint sensor={sensor.value} {date} {region} {fetcher} />
       the 7 day average of
       <strong>{sensor.name}</strong>
       <UIKitHint title={sensor.signalTooltip} inline />


### PR DESCRIPTION
possible workaround/fix for #1123 and #1026

**Prerequisites**:

- [x] Unless it is a hotfix it should be merged against the `dev` branch
- [x] Branch is up-to-date with the branch to be merged with, i.e. `dev`
- [x] Build is successful
- [x] Code is cleaned up and formatted

### Summary

workaround for not having the real latest data date in the meta data

for the latest "show all data" + most recent tooltip