### PR TITLE
Auto merge dev upon release

### DIFF
--- a/.github/workflows/release_main.yml
+++ b/.github/workflows/release_main.yml
@@ -113,17 +113,5 @@ jobs:
       - name: Reset dev branch
         run: |
           git fetch origin main:main
-          git reset --hard main
-      - name: Create pull request into dev
-        uses: peter-evans/create-pull-request@v3
-        with:
-          token: ${{ secrets.CMU_DELPHI_DEPLOY_MACHINE_PAT }}
-          branch: bot/sync-main-dev
-          commit-message: 'chore: sync main-dev'
-          base: dev
-          title: 'chore: sync main->dev'
-          labels: chore
-          reviewers: krivard
-          # assignees:
-          body: |
-            Syncing Main->Dev.
+          git merge main
+          git push

--- a/.github/workflows/update_gdocs_data.yml
+++ b/.github/workflows/update_gdocs_data.yml
@@ -29,7 +29,7 @@ jobs:
           commit-message: 'chore: update docs'
           title: Update Google Docs Meta Data
           labels: chore
-          reviewers: krivard,sgratzl
-          assignees: sgratzl
+          reviewers: krivard
+          assignees: krivard
           body: |
             Updating Google Docs Meta Data

--- a/README.md
+++ b/README.md
@@ -71,7 +71,6 @@ The release consists of multiple steps which can be all done via the GitHub webs
 1. Let the code owner review the PR and its changes and let the CI check whether everything builds successfully
 1. Once approved and merged, another GitHub action job starts which automatically will
    1. create a git tag
-   1. create another [Pull Request](https://github.com/cmu-delphi/www-covidcast/pulls) to merge the changes back to the `dev` branch
    1. create a [GitHub release](https://github.com/cmu-delphi/www-covidcast/releases) with automatically derived release notes
    1. create a [Pull Request in www-main](https://github.com/cmu-delphi/www-main/pulls) to update the website to the new release
 1. Done


### PR DESCRIPTION
closes #1144 

**Prerequisites**:

- [x] Unless it is a hotfix it should be merged against the `dev` branch
- [x] Branch is up-to-date with the branch to be merged with, i.e. `dev`
- [x] Build is successful
- [x] Code is cleaned up and formatted

### Summary

merges the dev branch directly without creating a PR
