### PR TITLE
dblclick to select date in sparkline and line chart

### DIFF
--- a/src/blocks/HistoryLineChart.svelte
+++ b/src/blocks/HistoryLineChart.svelte
@@ -218,6 +218,16 @@
     }
   }
 
+  function onDblclick(event) {
+    let item = event.detail.item;
+    while (item && item.datum) {
+      item = item.datum;
+    }
+    if (item != null && item.date_value != null) {
+      date.set(item.date_value);
+    }
+  }
+
   function resolveRegions(region, singleRegionOnly, showNeighbors) {
     if (singleRegionOnly) {
       return [region];
@@ -338,6 +348,8 @@
   signals={{ highlight_tuple: resetOnClearHighlighTuple(date.value), highlightRegion }}
   signalListeners={['highlight']}
   on:signal={onSignal}
+  eventListeners={['dblclick']}
+  on:dblclick={onDblclick}
 />
 
 <div class="buttons">

--- a/src/blocks/IndicatorOverview.svelte
+++ b/src/blocks/IndicatorOverview.svelte
@@ -32,6 +32,16 @@
     highlightDate: 'top',
     highlightStartEnd: false,
   });
+
+  function onDblclick(event) {
+    let item = event.detail.item;
+    while (item && item.datum) {
+      item = item.datum;
+    }
+    if (item != null && item.date_value != null) {
+      date.set(item.date_value);
+    }
+  }
 </script>
 
 <div class="mobile-three-col">
@@ -65,6 +75,8 @@
         tooltip={SparkLineTooltip}
         tooltipProps={{ sensor: sensor }}
         signals={{ currentDate: date.value }}
+        eventListeners={['dblclick']}
+        on:dblclick={onDblclick}
       />
     </div>
     <div class="date-range">


### PR DESCRIPTION
closes #1159

**Prerequisites**:

- [x] Unless it is a hotfix it should be merged against the `dev` branch
- [x] Branch is up-to-date with the branch to be merged with, i.e. `dev`
- [x] Build is successful
- [x] Code is cleaned up and formatted

### Summary

currently supported in two locations: 
sparline on this page:

![image](https://user-images.githubusercontent.com/4129778/155858426-5e404745-7101-499d-bf62-3dcb522e1938.png)

and the line chart:

![image](https://user-images.githubusercontent.com/4129778/155858436-bc4b7be3-0ac9-400c-b582-70f14f4d76c2.png)

note: as commented in the original issue, changing the date will most likely change the chart itself, too. e.g. it will show a different date window. 