### PR TITLE
Sync descriptions and questions to delphi-epidata

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -45,8 +45,8 @@ jobs:
       - name: Copy files
         run: |
           ls -al
-          cp src/stores/descriptions.raw.txt delphi-epidata/src/server/endpoints/covidcast_utils/descriptions.raw.txt
-          cp src/stores/questions.raw.txt delphi-epidata/src/server/endpoints/covidcast_utils/questions.raw.txt
+          cp src/stores/descriptions.raw.txt src/stores/questions.raw.txt \
+             delphi-epidata/src/server/endpoints/covidcast_utils/
       - name: Create pull request into epidata
         uses: peter-evans/create-pull-request@v5
         with:

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -36,3 +36,27 @@ jobs:
           # assignees:
           body: |
             Releasing ${{ steps.version.outputs.next_tag }}.
+      - name: Check out delphi epidata 
+        uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.EPIDATA_PAT }}
+          repository: cmu-delphi/delphi-epidata
+          path: delphi-epidata
+      - name: Copy files
+        run: |
+          ls -al
+          cp src/stores/descriptions.raw.txt delphi-epidata/src/server/endpoints/covidcast_utils/descriptions.raw.txt
+          cp src/stores/questions.raw.txt delphi-epidata/src/server/endpoints/covidcast_utils/questions.raw.txt
+      - name: Create pull request into epidata
+        uses: peter-evans/create-pull-request@v5
+        with:
+          path: delphi-epidata
+          token: ${{ secrets.EPIDATA_PAT }}
+          branch: www-covidcast-release/${{ steps.version.outputs.next_tag }}
+          commit-message: 'chore: sync to www-covidcast release ${{ steps.version.outputs.next_tag }}'
+          base: dev
+          title: Sync to www-covidcast release ${{ steps.version.outputs.next_tag }}
+          labels: chore
+          reviewers: krivard
+          body: |
+            Syncing covidcast_utils files to www-covidcast release ${{ steps.version.outputs.next_tag }}.

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -44,7 +44,6 @@ jobs:
           path: delphi-epidata
       - name: Copy files
         run: |
-          ls -al
           cp src/stores/descriptions.raw.txt src/stores/questions.raw.txt \
              delphi-epidata/src/server/endpoints/covidcast_utils/
       - name: Create pull request into epidata

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Check out delphi epidata 
         uses: actions/checkout@v3
         with:
-          token: ${{ secrets.EPIDATA_PAT }}
+          token: ${{ secrets.CMU_DELPHI_DEPLOY_MACHINE_PAT }}
           repository: cmu-delphi/delphi-epidata
           path: delphi-epidata
       - name: Copy files
@@ -50,7 +50,7 @@ jobs:
         uses: peter-evans/create-pull-request@v5
         with:
           path: delphi-epidata
-          token: ${{ secrets.EPIDATA_PAT }}
+          token: ${{ secrets.CMU_DELPHI_DEPLOY_MACHINE_PAT }}
           branch: www-covidcast-release/${{ steps.version.outputs.next_tag }}
           commit-message: 'chore: sync to www-covidcast release ${{ steps.version.outputs.next_tag }}'
           base: dev


### PR DESCRIPTION
**Prerequisites**:

- [X] Unless it is a hotfix it should be merged against the `dev` branch
- [X] Branch is up-to-date with the branch to be merged with, i.e. `dev`
- [X] Build is successful
- [X] Code is cleaned up and formatted

### Summary

As part of the "Create Release" action in the `www-covidcast` repo, creates a PR in the `delphi-epidata` repo that updates (copies) two text files from `www-covidcast`.

Tested out in [my fork of this repo](https://github.com/rzats/www-covidcast). A link to a successful run can be found [here](https://github.com/rzats/www-covidcast/actions/runs/4821894836), and the PR it created it is https://github.com/cmu-delphi/delphi-epidata/pull/1154.

**PREREQUISITE: Add a secret to this repo called `EPIDATA_PAT`, which is a personal access token with access to both this repo and `delphi-epidata`.**