### PR TITLE
Remove inactive sources from indicator status dashboard

### DIFF
--- a/src/modes/indicator-status/IndicatorStatusTable.svelte
+++ b/src/modes/indicator-status/IndicatorStatusTable.svelte
@@ -9,6 +9,7 @@
   import chevronRightIcon from '!raw-loader!@fortawesome/fontawesome-free/svgs/solid/chevron-right.svg';
   import { metaDataManager } from '../../stores';
   import { loadData } from './data';
+  import { INACTIVE_DATA_SOURCES } from './store';
 
   const dispatch = createEventDispatcher();
 
@@ -29,6 +30,7 @@
     sortedData = loader.initial;
     const comparator = $sort.comparator;
     loader.loaded.then((rows) => {
+      rows = rows.filter((r) => !INACTIVE_DATA_SOURCES.includes(r.source));
       sortedData = rows.slice().sort(comparator);
       loading = false;
     });

--- a/src/modes/indicator-status/IndicatorStatusTable.svelte
+++ b/src/modes/indicator-status/IndicatorStatusTable.svelte
@@ -9,7 +9,6 @@
   import chevronRightIcon from '!raw-loader!@fortawesome/fontawesome-free/svgs/solid/chevron-right.svg';
   import { metaDataManager } from '../../stores';
   import { loadData } from './data';
-  import { INACTIVE_DATA_SOURCES } from './store';
 
   const dispatch = createEventDispatcher();
 
@@ -30,7 +29,7 @@
     sortedData = loader.initial;
     const comparator = $sort.comparator;
     loader.loaded.then((rows) => {
-      rows = rows.filter((r) => !INACTIVE_DATA_SOURCES.includes(r.source));
+      rows = rows.filter((r) => r.latest_lag_days <= 180);
       sortedData = rows.slice().sort(comparator);
       loading = false;
     });

--- a/src/modes/indicator-status/IndicatorStatusTable.svelte
+++ b/src/modes/indicator-status/IndicatorStatusTable.svelte
@@ -29,6 +29,7 @@
     sortedData = loader.initial;
     const comparator = $sort.comparator;
     loader.loaded.then((rows) => {
+      // do not display signals that are "active" but more than 6 months out of date
       rows = rows.filter((r) => r.latest_lag_days <= 180);
       sortedData = rows.slice().sort(comparator);
       loading = false;

--- a/src/modes/indicator-status/store.ts
+++ b/src/modes/indicator-status/store.ts
@@ -28,5 +28,3 @@ export const valueLabel = derived(
   ([value, options]) => options.find((d) => d.value == value)!.label,
 );
 export const isRelative = derived([valueField], ([v]) => v.endsWith('_rel_change'));
-
-export const INACTIVE_DATA_SOURCES = ['dsew-cpr', 'fb-survey', 'jhu-csse', 'safegraph-weekly', 'usa-facts'];

--- a/src/modes/indicator-status/store.ts
+++ b/src/modes/indicator-status/store.ts
@@ -28,3 +28,5 @@ export const valueLabel = derived(
   ([value, options]) => options.find((d) => d.value == value)!.label,
 );
 export const isRelative = derived([valueField], ([v]) => v.endsWith('_rel_change'));
+
+export const INACTIVE_DATA_SOURCES = ['dsew-cpr', 'fb-survey', 'jhu-csse', 'safegraph-weekly', 'usa-facts'];


### PR DESCRIPTION
**Prerequisites**:

- [X] Unless it is a hotfix it should be merged against the `dev` branch
- [X] Branch is up-to-date with the branch to be merged with, i.e. `dev`
- [x] Build is successful
- [X] Code is cleaned up and formatted

### Summary

Prevents the inactive/stale sensors from showing up in the indicator status dashboard. Before:

<img width="809" alt="Screenshot 2023-09-22 at 18 11 38" src="https://github.com/cmu-delphi/www-covidcast/assets/13783592/8a2f0cbf-fcdf-4a3b-aa9b-bb96974d1c8f">

After:

<img width="820" alt="Screenshot 2023-09-22 at 18 11 04" src="https://github.com/cmu-delphi/www-covidcast/assets/13783592/67eaa1ac-ca14-499c-8cb6-800cec188b37">