### PR TITLE
Assorted dashboard cleanup tasks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14900,7 +14900,7 @@
     },
     "node_modules/vega-embed/node_modules/yallist": {
       "version": "4.0.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC"
     },
@@ -27155,7 +27155,7 @@
         "yallist": {
           "version": "4.0.0",
           "bundled": true,
-          "dev": true
+          "extraneous": true
         }
       }
     },

--- a/src/data/meta.ts
+++ b/src/data/meta.ts
@@ -195,7 +195,7 @@ export class MetaDataManager {
     return this.getSensor({ id: 'jhu-csse', signal: 'confirmed_7dav_incidence_prop' });
   }
   getDefaultDeathSignal(): Sensor | null {
-    return this.getSensor({ id: 'jhu-csse', signal: 'deaths_7dav_incidence_prop' });
+    return this.getSensor({ id: 'nchs-mortality', signal: 'deaths_covid_incidence_prop' });
   }
 
   getSensorsOfType(type: SignalCategory): Sensor[] {

--- a/src/modes/summary/Summary.svelte
+++ b/src/modes/summary/Summary.svelte
@@ -1,6 +1,5 @@
 <script>
   import IndicatorTable from './IndicatorTable.svelte';
-  import Overview from './Overview.svelte';
   import { countyInfo, nationInfo, stateInfo } from '../../data/regions';
   import RegionDatePicker from '../../components/RegionDatePicker.svelte';
   import {
@@ -69,17 +68,14 @@
   </RegionDatePicker>
   <div class="uk-container content-grid">
     <div class="grid-3-11">
-      <FancyHeader invert>{region.displayName}</FancyHeader>
-      <Overview {date} {region} {fetcher} />
-      <hr />
-      <FancyHeader invert sub="Map" anchor="map">{HOSPITAL_ADMISSION.name}</FancyHeader>
-      <p>{@html HOSPITAL_ADMISSION.signalTooltip}</p>
-      <RegionMapWrapper {region} {date} sensor={HOSPITAL_ADMISSION} {fetcher} />
-      <hr />
       <FancyHeader invert sub="Chart" anchor="chart">{HOSPITAL_ADMISSION.name}</FancyHeader>
       <div class="chart-300">
         <HistoryLineChart sensor={HOSPITAL_ADMISSION} {date} {region} {fetcher} />
       </div>
+      <hr />
+      <FancyHeader invert sub="Map" anchor="map">{HOSPITAL_ADMISSION.name}</FancyHeader>
+      <p>{@html HOSPITAL_ADMISSION.signalTooltip}</p>
+      <RegionMapWrapper {region} {date} sensor={HOSPITAL_ADMISSION} {fetcher} />
       <hr />
       <IndicatorTable {date} {region} {fetcher} />
     </div>

--- a/src/stores/descriptions.raw.txt
+++ b/src/stores/descriptions.raw.txt
@@ -43,18 +43,6 @@ SignalTooltip: Percentage of daily doctor visits that are due to lab-confirmed i
 
 Description: Delphi receives aggregated statistics from Change Healthcare, Inc. on lab-confirmed influenza outpatient doctor visits, derived from ICD codes found in insurance claims. Using this data, we estimate the percentage of daily doctor’s visits in each area that resulted in a diagnosis of influenza. Note that these estimates are based only on visits by patients whose insurance claims are accessible to Change Healthcare.
 ---
-Name: COVID Cases
-Id: jhu-csse
-Signal: confirmed_7dav_incidence_prop
-Highlight: [default]
-ExtendedColorScale: true
-
-
-SignalTooltip: Newly reported COVID-19 cases per 100,000 people, based on data from Johns Hopkins University
-
-
-Description: This data shows the number of COVID-19 confirmed cases newly reported each day. It reflects only cases reported by state and local health authorities. It is based on case counts compiled and made public by [a team at Johns Hopkins University](https://systems.jhu.edu/research/public-health/ncov/). The signal may not be directly comparable across regions with vastly different testing capacity or reporting criteria. 
----
 Name: COVID Hospital Admissions
 Id: hhs
 Signal: confirmed_admissions_covid_1d_prop_7dav
@@ -89,11 +77,11 @@ SignalTooltip: Confirmed influenza hospital admissions per 100,000 people
 Description: This data shows the number of hospital admissions with lab-confirmed influenza each day. We source this data from the Report on Patient Impact and Hospital Capacity published by the US Department of Health & Human Services (HHS). 
 ---
 Name: COVID Deaths
-Id: jhu-csse
-Signal: deaths_7dav_incidence_prop
+Id: nchs-mortality
+Signal: deaths_covid_incidence_prop
 
 
-SignalTooltip: Newly reported COVID-19 deaths per 100,000 people, based on data from Johns Hopkins University
+SignalTooltip: Newly reported COVID-19 deaths per 100,000 people, based on NCHS mortality data.
 
 
-Description: This data shows the number of COVID-19 deaths newly reported each day. The signal is based on COVID-19 death counts compiled and made public by [a team at Johns Hopkins University](https://systems.jhu.edu/research/public-health/ncov/).
+Description: This data source of national provisional death counts is based on death certificate data received and coded by the National Center for Health Statistics (NCHS). This data is different from the death data available from USAFacts and JHU CSSE. Deaths are reported by the date they occur, not the date they are reported by local health departments, and data is frequently reissued as additional death certificates from recent weeks are received and tabulated.

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -115,7 +115,7 @@ export const defaultHospitalSensor = derived(sensorList, (sensorList) => {
   return sensorList.find((d) => d.signal === 'confirmed_admissions_covid_1d_prop_7dav');
 });
 export const defaultDeathSensor = derived(sensorList, (sensorList) => {
-  return sensorList.find((d) => d.signal === 'deaths_7dav_incidence_prop');
+  return sensorList.find((d) => d.signal === 'deaths_covid_incidence_prop');
 });
 
 export const currentSensorEntry = derived(


### PR DESCRIPTION
Closes #1233.

**Prerequisites**:

- [X] Unless it is a hotfix it should be merged against the `dev` branch
- [X] Branch is up-to-date with the branch to be merged with, i.e. `dev`
- [x] Build is successful
- [X] Code is cleaned up and formatted

### Summary

Implements the changes requested for the Covidcast dashboard:

- Removes the top section (7-day averages and comparisons).
- Moves the COVID hospital admissions chart to top of page (above the beehive map).
- Removes COVID cases from the indicators table.
- Replaces JHU deaths (jhu-csse deaths_7dav_incidence_prop) with NCHS deaths (nchs-mortality deaths_covid_incidence_prop).

<img width="552" alt="Screenshot 2023-10-26 at 18 26 47" src="https://github.com/cmu-delphi/www-covidcast/assets/13783592/3647f13d-6899-46f4-9f22-eb793f2d2199">

<img width="574" alt="Screenshot 2023-10-26 at 18 26 52" src="https://github.com/cmu-delphi/www-covidcast/assets/13783592/6fa10f1f-1e20-4907-a041-7a8671f88a1c">
