### PR TITLE
Dashboard signal swaps

### DIFF
--- a/src/data/meta.ts
+++ b/src/data/meta.ts
@@ -192,10 +192,10 @@ export class MetaDataManager {
   }
 
   getDefaultCasesSignal(): Sensor | null {
-    return this.getSensor({ id: 'jhu-csse', signal: 'confirmed_7dav_incidence_prop' });
+    return this.getSensor({ id: 'doctor-visits', signal: 'smoothed_adj_cli' });
   }
   getDefaultDeathSignal(): Sensor | null {
-    return this.getSensor({ id: 'jhu-csse', signal: 'deaths_7dav_incidence_prop' });
+    return this.getSensor({ id: 'nchs-mortality', signal: 'deaths_covid_incidence_prop' });
   }
 
   getSensorsOfType(type: SignalCategory): Sensor[] {

--- a/src/modes/summary/Overview.svelte
+++ b/src/modes/summary/Overview.svelte
@@ -53,7 +53,7 @@
 
 <div class="mobile-three-col">
   <div class="mobile-kpi">
-    <h3>Cases</h3>
+    <h3>Doctor Visits</h3>
     <div>
       {#await casesTrend}
         <KPIValue value={null} loading />

--- a/src/modes/summary/Overview.svelte
+++ b/src/modes/summary/Overview.svelte
@@ -88,7 +88,7 @@
       {/await}
     </div>
     <div class="sub">
-      <SensorUnit sensor={CASES} long />
+      <SensorUnit sensor={DEATHS} long />
     </div>
   </div>
 </div>

--- a/src/modes/summary/Summary.svelte
+++ b/src/modes/summary/Summary.svelte
@@ -1,6 +1,7 @@
 <script>
   import IndicatorTable from './IndicatorTable.svelte';
-  import Overview from './Overview.svelte';
+  // TEMPORARY DISABLING OF THIS OVERVIEW WIDGET UNTIL SIGNALS ARE FIXED:
+  // import Overview from './Overview.svelte';
   import { countyInfo, nationInfo, stateInfo } from '../../data/regions';
   import RegionDatePicker from '../../components/RegionDatePicker.svelte';
   import {

--- a/src/modes/summary/Summary.svelte
+++ b/src/modes/summary/Summary.svelte
@@ -70,7 +70,9 @@
   <div class="uk-container content-grid">
     <div class="grid-3-11">
       <FancyHeader invert>{region.displayName}</FancyHeader>
+      <!-- TEMPORARY DISABLING OF THIS OVERVIEW WIDGET UNTIL SIGNALS ARE FIXED
       <Overview {date} {region} {fetcher} />
+      -->
       <hr />
       <FancyHeader invert sub="Map" anchor="map">{HOSPITAL_ADMISSION.name}</FancyHeader>
       <p>{@html HOSPITAL_ADMISSION.signalTooltip}</p>

--- a/src/stores/descriptions.raw.txt
+++ b/src/stores/descriptions.raw.txt
@@ -43,18 +43,6 @@ SignalTooltip: Percentage of daily doctor visits that are due to lab-confirmed i
 
 Description: Delphi receives aggregated statistics from Change Healthcare, Inc. on lab-confirmed influenza outpatient doctor visits, derived from ICD codes found in insurance claims. Using this data, we estimate the percentage of daily doctor’s visits in each area that resulted in a diagnosis of influenza. Note that these estimates are based only on visits by patients whose insurance claims are accessible to Change Healthcare.
 ---
-Name: COVID Cases
-Id: jhu-csse
-Signal: confirmed_7dav_incidence_prop
-Highlight: [default]
-ExtendedColorScale: true
-
-
-SignalTooltip: Newly reported COVID-19 cases per 100,000 people, based on data from Johns Hopkins University
-
-
-Description: This data shows the number of COVID-19 confirmed cases newly reported each day. It reflects only cases reported by state and local health authorities. It is based on case counts compiled and made public by [a team at Johns Hopkins University](https://systems.jhu.edu/research/public-health/ncov/). The signal may not be directly comparable across regions with vastly different testing capacity or reporting criteria. 
----
 Name: COVID Hospital Admissions
 Id: hhs
 Signal: confirmed_admissions_covid_1d_prop_7dav
@@ -89,11 +77,11 @@ SignalTooltip: Confirmed influenza hospital admissions per 100,000 people
 Description: This data shows the number of hospital admissions with lab-confirmed influenza each day. We source this data from the Report on Patient Impact and Hospital Capacity published by the US Department of Health & Human Services (HHS). 
 ---
 Name: COVID Deaths
-Id: jhu-csse
-Signal: deaths_7dav_incidence_prop
+Id: nchs-mortality
+Signal: deaths_covid_incidence_prop
 
 
-SignalTooltip: Newly reported COVID-19 deaths per 100,000 people, based on data from Johns Hopkins University
+SignalTooltip: Newly reported COVID-19 deaths per 100,000 people, based on NCHS mortality data.
 
 
-Description: This data shows the number of COVID-19 deaths newly reported each day. The signal is based on COVID-19 death counts compiled and made public by [a team at Johns Hopkins University](https://systems.jhu.edu/research/public-health/ncov/).
+Description: This data shows the number of COVID-19 deaths newly reported each week. The signal is based on COVID-19 death counts compiled and made public by [the National Center for Health Statistics](https://www.cdc.gov/nchs/nvss/vsrr/COVID19/index.htm).

--- a/src/stores/descriptions.raw.txt
+++ b/src/stores/descriptions.raw.txt
@@ -51,8 +51,8 @@ ExtendedColorScale: true
 Levels: [nation, state, county]
 Overrides:
   County:
-    Id: dsew-cpr
-    Signal: confirmed_admissions_covid_1d_prop_7dav
+    Id: hospital-admissions
+    Signal: smoothed_adj_covid19_from_claims
 
 
 

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -109,13 +109,13 @@ export const sensorList = derived(metaDataManager, (metaData) => {
 });
 
 export const defaultCasesSensor = derived(sensorList, (sensorList) => {
-  return sensorList.find((d) => d.signal === 'confirmed_7dav_incidence_prop');
+  return sensorList.find((d) => d.signal === 'smoothed_adj_cli');
 });
 export const defaultHospitalSensor = derived(sensorList, (sensorList) => {
   return sensorList.find((d) => d.signal === 'confirmed_admissions_covid_1d_prop_7dav');
 });
 export const defaultDeathSensor = derived(sensorList, (sensorList) => {
-  return sensorList.find((d) => d.signal === 'deaths_7dav_incidence_prop');
+  return sensorList.find((d) => d.signal === 'deaths_covid_incidence_prop');
 });
 
 export const currentSensorEntry = derived(


### PR DESCRIPTION
Removing now-defunct JHU signals from the dashboard: replacing the deaths signal with one from `nchs-mortality` (which hasnt been used in the dashboard before), and replacing the cases signal with `doctor-visits`.