### PR TITLE
Set COVIDcast export values based on URL parameters

### DIFF
--- a/src/modes/exportdata/ExportData.svelte
+++ b/src/modes/exportdata/ExportData.svelte
@@ -56,8 +56,8 @@
     endDate = urlParams.has('end_day') ? new Date(urlParams.get('end_day')) : param.sparkLineTimeFrame.max;
 
     // Also normalize the dates to the current timezone
-    startDate = new Date(startDate.getTime() + Math.abs(startDate.getTimezoneOffset() * 60000));
-    endDate = new Date(endDate.getTime() + Math.abs(endDate.getTimezoneOffset() * 60000));
+    startDate = new Date(startDate.getTime() - startDate.getTimezoneOffset() * -60000);
+    endDate = new Date(endDate.getTime() - endDate.getTimezoneOffset() * -60000);
   }
   $: initDate($currentDateObject);
 
@@ -122,7 +122,7 @@
     asOfMode = 'single';
     asOfDate = new Date(urlParams.get('as_of'));
     // Also normalize the dates to the current timezone
-    asOfDate = new Date(asOfDate.getTime() + Math.abs(asOfDate.getTimezoneOffset() * 60000));
+    asOfDate = new Date(asOfDate.getTime() - asOfDate.getTimezoneOffset() * -60000);
   }
 
   let form = null;

--- a/src/modes/exportdata/ExportData.svelte
+++ b/src/modes/exportdata/ExportData.svelte
@@ -54,6 +54,10 @@
     // Populate date based on URL params or, if absent, the current date
     startDate = urlParams.has('start_day') ? new Date(urlParams.get('start_day')) : param.sparkLineTimeFrame.min;
     endDate = urlParams.has('end_day') ? new Date(urlParams.get('end_day')) : param.sparkLineTimeFrame.max;
+
+    // Also normalize the dates to the current timezone
+    startDate = new Date(startDate.getTime() + Math.abs(startDate.getTimezoneOffset() * 60000));
+    endDate = new Date(endDate.getTime() + Math.abs(endDate.getTimezoneOffset() * 60000));
   }
   $: initDate($currentDateObject);
 
@@ -117,6 +121,8 @@
   if (urlParams.has('as_of') && !isNaN(new Date(urlParams.get('as_of')))) {
     asOfMode = 'single';
     asOfDate = new Date(urlParams.get('as_of'));
+    // Also normalize the dates to the current timezone
+    asOfDate = new Date(asOfDate.getTime() + Math.abs(asOfDate.getTimezoneOffset() * 60000));
   }
 
   let form = null;

--- a/src/modes/exportdata/ExportData.svelte
+++ b/src/modes/exportdata/ExportData.svelte
@@ -54,8 +54,24 @@
     // Populate date based on URL params or, if absent, the current date
     if (sensor && !sensor.active) {
       // If the sensor is inactive, set the start and end dates to its historical range rather than current date
-      startDate = urlParams.has('start_day') ? new Date(urlParams.get('start_day')) : sensor.meta.minTime;
-      endDate = urlParams.has('end_day') ? new Date(urlParams.get('end_day')) : sensor.meta.maxTime;
+      if (
+        urlParams.has('start_day') &&
+        new Date(urlParams.get('start_day')) >= sensor.meta.minTime &&
+        new Date(urlParams.get('start_day')) <= sensor.meta.maxTime
+      ) {
+        startDate = new Date(urlParams.get('start_day'));
+      } else {
+        startDate = sensor.meta.minTime;
+      }
+      if (
+        urlParams.has('end_day') &&
+        new Date(urlParams.get('end_day')) <= sensor.meta.minTime &&
+        new Date(urlParams.get('end_day')) <= sensor.meta.maxTime
+      ) {
+        endDate = new Date(urlParams.get('end_day'));
+      } else {
+        endDate = sensor.meta.maxTime;
+      }
     } else {
       startDate = urlParams.has('start_day') ? new Date(urlParams.get('start_day')) : param.sparkLineTimeFrame.min;
       endDate = urlParams.has('end_day') ? new Date(urlParams.get('end_day')) : param.sparkLineTimeFrame.max;

--- a/src/modes/exportdata/ExportData.svelte
+++ b/src/modes/exportdata/ExportData.svelte
@@ -28,7 +28,7 @@
   }
 
   // Pre-fill the form from URL parameters.
-  // Supported parameters: source, sensor, start, end, geo_type, geo_id
+  // Supported parameters: data_source, signal, start_day, end_day, geo_type, geo_value, as_of
   const urlParams = new URLSearchParams(window.location.search);
 
   // Overwrite default source & sensor if these are present in the URL
@@ -52,30 +52,8 @@
     const param = new DateParam(date);
 
     // Populate date based on URL params or, if absent, the current date
-    if (sensor && !sensor.active) {
-      // If the sensor is inactive, set the start and end dates to its historical range rather than current date
-      if (
-        urlParams.has('start_day') &&
-        new Date(urlParams.get('start_day')) >= sensor.meta.minTime &&
-        new Date(urlParams.get('start_day')) <= sensor.meta.maxTime
-      ) {
-        startDate = new Date(urlParams.get('start_day'));
-      } else {
-        startDate = sensor.meta.minTime;
-      }
-      if (
-        urlParams.has('end_day') &&
-        new Date(urlParams.get('end_day')) <= sensor.meta.minTime &&
-        new Date(urlParams.get('end_day')) <= sensor.meta.maxTime
-      ) {
-        endDate = new Date(urlParams.get('end_day'));
-      } else {
-        endDate = sensor.meta.maxTime;
-      }
-    } else {
-      startDate = urlParams.has('start_day') ? new Date(urlParams.get('start_day')) : param.sparkLineTimeFrame.min;
-      endDate = urlParams.has('end_day') ? new Date(urlParams.get('end_day')) : param.sparkLineTimeFrame.max;
-    }
+    startDate = urlParams.has('start_day') ? new Date(urlParams.get('start_day')) : param.sparkLineTimeFrame.min;
+    endDate = urlParams.has('end_day') ? new Date(urlParams.get('end_day')) : param.sparkLineTimeFrame.max;
   }
   $: initDate($currentDateObject);
 

--- a/src/modes/exportdata/ExportData.svelte
+++ b/src/modes/exportdata/ExportData.svelte
@@ -27,6 +27,8 @@
     }
   }
 
+  // Pre-fill the form from URL parameters.
+  // Supported parameters: source, sensor, start, end, geo_type, geo_id
   const urlParams = new URLSearchParams(window.location.search);
 
   // Overwrite default source & sensor if these are present in the URL
@@ -41,7 +43,7 @@
   $: isWeekly = sensor ? sensor.isWeeklySignal : false;
   $: formatDate = isWeekly ? (d) => formatWeek(d).replace('W', '') : formatDateISO;
 
-  let geoType = urlParams.has('geo') ? urlParams.get('geo') : 'county';
+  let geoType = urlParams.has('geo_type') ? urlParams.get('geo_type') : 'county';
 
   let startDate = new Date();
   let endDate = new Date();
@@ -72,11 +74,19 @@
 
   let geoValuesMode = 'all';
   let geoValues = [];
+  let geoURLSet = false;
   $: geoItems = [...(infosByLevel[geoType] || []), ...(geoType === 'county' ? infosByLevel.state : [])];
   $: {
     if (geoItems != null) {
       geoValues = [];
       geoValuesMode = guessMode(geoItems.length);
+    }
+
+    // Populate region based on URL params... but let the user override this later
+    if (urlParams.has('geo_id') && !geoURLSet) {
+      let infos = infosByLevel[geoType].filter((d) => d.propertyId == urlParams.get('geo_id'));
+      addRegion(infos[0]);
+      geoURLSet = true;
     }
   }
 

--- a/src/modes/exportdata/ExportData.svelte
+++ b/src/modes/exportdata/ExportData.svelte
@@ -27,18 +27,31 @@
     }
   }
 
+  const urlParams = new URLSearchParams(window.location.search);
+
+  // Overwrite default source & sensor if these are present in the URL
+  if (urlParams.has('source')) {
+    sourceValue = urlParams.get('source');
+
+    if (urlParams.has('sensor')) {
+      sensorValue = urlParams.get('sensor');
+    }
+  }
+
   $: isWeekly = sensor ? sensor.isWeeklySignal : false;
   $: formatDate = isWeekly ? (d) => formatWeek(d).replace('W', '') : formatDateISO;
 
-  let geoType = 'county';
+  let geoType = urlParams.has('geo') ? urlParams.get('geo') : 'county';
 
   let startDate = new Date();
   let endDate = new Date();
 
   function initDate(date) {
     const param = new DateParam(date);
-    endDate = param.sparkLineTimeFrame.max;
-    startDate = param.sparkLineTimeFrame.min;
+
+    // Populate date based on URL params or, if absent, the current date
+    startDate = urlParams.has('start') ? new Date(urlParams.get('start')) : param.sparkLineTimeFrame.min;
+    endDate = urlParams.has('end') ? new Date(urlParams.get('end')) : param.sparkLineTimeFrame.max;
   }
   $: initDate($currentDateObject);
 


### PR DESCRIPTION
**Prerequisites**:

- [X] Unless it is a hotfix it should be merged against the `dev` branch
- [X] Branch is up-to-date with the branch to be merged with, i.e. `dev`
- [x] Build is successful
- [x] Code is cleaned up and formatted

### Summary

Fills in the form values on the COVIDcast Export Data page based on URL parameters. This will be used to integrate the export UI with e.g. the EpiVis dashboard or signal documentation, with certain values being pre-filled based on parameters selected on another section of the website.

To test this out, visit the export dashboard on the preview website, then append this set of parameters to the URL:
```
/?data_source=covid-act-now&signal=covid-act-now-pcr_specimen_total_tests&start_day=2024-01-01&end_day=2024-02-02&geo_type=state
```