### PR TITLE
Update COVIDcast export integration

### DIFF
--- a/src/modes/exportdata/ExportData.svelte
+++ b/src/modes/exportdata/ExportData.svelte
@@ -55,7 +55,8 @@
     startDate = urlParams.has('start_day') ? new Date(urlParams.get('start_day')) : param.sparkLineTimeFrame.min;
     endDate = urlParams.has('end_day') ? new Date(urlParams.get('end_day')) : param.sparkLineTimeFrame.max;
 
-    // Also normalize the dates to the current timezone
+    // Normalize the datest to the current timezone by *subtracting* the timezone
+    // offset (to account for negative timezones), multiplied by 60000 (minutes -> ms)
     startDate = new Date(startDate.getTime() - startDate.getTimezoneOffset() * -60000);
     endDate = new Date(endDate.getTime() - endDate.getTimezoneOffset() * -60000);
   }
@@ -88,7 +89,7 @@
 
     // Populate region based on URL params... but let the user override this later
     if (urlParams.has('geo_value') && !geoURLSet) {
-      let infos = infosByLevel[geoType].filter((d) => d.propertyId == urlParams.get('geo_value'));
+      let infos = infosByLevel[geoType].filter((d) => d.propertyId == urlParams.get('geo_value').toUpperCase());
       addRegion(infos[0]);
       geoURLSet = true;
     }

--- a/src/modes/exportdata/ExportData.svelte
+++ b/src/modes/exportdata/ExportData.svelte
@@ -89,7 +89,12 @@
 
     // Populate region based on URL params... but let the user override this later
     if (urlParams.has('geo_value') && !geoURLSet) {
-      let infos = infosByLevel[geoType].filter((d) => d.propertyId == urlParams.get('geo_value').toUpperCase());
+      let geo_value = urlParams.get('geo_value');
+      // Allow for lowercase state names e.g. 'ca' -> 'CA'
+      if (geoType == 'state') {
+        geo_value = geo_value.toUpperCase();
+      }
+      let infos = infosByLevel[geoType].filter((d) => d.propertyId == geo_value);
       addRegion(infos[0]);
       geoURLSet = true;
     }

--- a/src/modes/indicator/Indicator.svelte
+++ b/src/modes/indicator/Indicator.svelte
@@ -96,7 +96,7 @@
         <HistoryLineChart {sensor} {date} {region} {fetcher} />
       </div>
     </div>
-    <IndicatorAbout {sensor} />
+    <IndicatorAbout {sensor} {region} {date} />
     <div class="grid-3-11">
       <hr />
       <GeoTable {sensor} {region} {date} {fetcher} />

--- a/src/modes/indicator/IndicatorAbout.svelte
+++ b/src/modes/indicator/IndicatorAbout.svelte
@@ -1,10 +1,19 @@
 <script>
   import { modeByID } from '..';
+  import { formatDateISO } from '../../formats';
   import { currentMode } from '../../stores';
   import AboutSection from '../../components/AboutSection.svelte';
 
   /**
-   * @type {import('../../stores/params').SensorParam}
+   * @type {import("../stores/params").DateParam}
+   */
+  export let date;
+  /**
+   * @type {import("../stores/params").RegionParam}
+   */
+  export let region;
+  /**
+   * @type {import("../stores/params").SensorParam}
    */
   export let sensor;
 
@@ -12,6 +21,24 @@
     sensor.set(sensor.value);
     // switch to export mode
     currentMode.set(modeByID.export);
+  }
+
+  function buildExportURL() {
+    let exportURL = '';
+    if (sensor.key.split('-').length >= 2) {
+      // account for dashes in the sensor
+      let [first, ...rest] = sensor.key.split('-');
+      rest = rest.join('-');
+      exportURL += `data_source=${first}&signal=${rest}`;
+    }
+    if (region) {
+      exportURL += `&geo_type=${region.level}&geo_value=${region.propertyId}`;
+    }
+    if (date) {
+      console.log(date);
+      exportURL += `&start_day=${formatDateISO(date.value)}&end_day=${formatDateISO(date.value)}`;
+    }
+    return exportURL;
   }
 </script>
 
@@ -33,7 +60,7 @@
             </li>
           {/each}
           <li>
-            <a href={`../${modeByID.export.id}?sensor=${sensor.key}`} on:click|preventDefault={exportData}
+            <a href={`../${modeByID.export.id}/?${buildExportURL()}`} on:click|preventDefault={exportData}
               >Export Data</a
             >
           </li>


### PR DESCRIPTION
Followup to #36.

**Prerequisites**:

- [x] Unless it is a hotfix it should be merged against the `dev` branch
- [x] Branch is up-to-date with the branch to be merged with, i.e. `dev`
- [ ] Build is successful
- [x] Code is cleaned up and formatted

### Summary

Fixes some pending issues from #36:
- Makes sure `geo_value` works for lowercase state names.
- Adds code comment about timezone conversions, especially explaining the weird double negative.
- Makes the indicator dashboard correctly integrate with the export dashboard, turning its parameters (sensor, region and date) into URL parameters. Link for testing TBD.