### PR TITLE
Fixed default date for the particular indicator(signal) dashboard

### DIFF
--- a/src/blocks/IndicatorWarning.svelte
+++ b/src/blocks/IndicatorWarning.svelte
@@ -26,6 +26,18 @@
   function switchDate() {
     date.set(sensor.timeFrame.max);
   }
+  function preserveUrlParams() {
+    let params = window.location.search;
+    console.log(sensor);
+    let result = new URLSearchParams();
+    result.append('date', formatAPITime(sensor.timeFrame.max));
+    result.append('sensor', sensor.key);
+    let regionParam = new URLSearchParams(params).get('region');
+    if (regionParam) {
+      result.append('region', regionParam);
+    }
+    return result.toString();
+  }
 </script>
 
 {#if !sensor.value.levels.includes(region.level)}
@@ -38,14 +50,7 @@
       <div data-uk-alert class="uk-alert-warning">
         The indicator "{sensor.name}" is not available for {formatDateYearDayOfWeekAbbr(date.value)}, yet. The latest
         known data is available on
-        <!-- 
-        window.location.search.split('&').slice(1).join('&') is used to keep the query parameters except the date parameter.
-        So we are getting query params from url, splitting them by & and removing the first element which is date parameter.
-         -->
-        <a
-          href="?date={formatAPITime(sensor.timeFrame.max)}&{window.location.search.split('&').slice(1).join('&')}"
-          on:click={switchDate}>{formatDateYearDayOfWeekAbbr(sensor.timeFrame.max)}</a
-        >.
+        <a href="?{preserveUrlParams()}" on:click={switchDate}>{formatDateYearDayOfWeekAbbr(sensor.timeFrame.max)}</a>.
       </div>
     {/if}
   {/await}

--- a/src/modes/summary/IndicatorTable.svelte
+++ b/src/modes/summary/IndicatorTable.svelte
@@ -146,11 +146,7 @@
               range="sparkLine"
               className="mobile-row-annotation"
             />
-            <a
-              href="../indicator?sensor={entry.sensor.key}"
-              class="uk-link-text"
-              on:click|preventDefault={entry.switchMode}
-            >
+            <a href="../indicator?sensor={entry.sensor.key}" class="uk-link-text">
               {entry.sensor.name}
               <span class="source-name">({cleanSource(entry.sensor.value.dataSourceName)})</span>
             </a>
@@ -199,11 +195,7 @@
             </div>
           </td>
           <td>
-            <a
-              href="../indicator?sensor={entry.sensor.key}"
-              class="uk-link-text details-link"
-              on:click|preventDefault={entry.switchMode}
-            >
+            <a href="../indicator?sensor={entry.sensor.key}" class="uk-link-text details-link">
               {@html chevronRightIcon}
             </a>
           </td>


### PR DESCRIPTION
**Prerequisites**:

- [x] Unless it is a hotfix it should be merged against the `dev` branch
- [x] Branch is up-to-date with the branch to be merged with, i.e. `dev`
- [x] Build is successful
- [x] Code is cleaned up and formatted

### Summary

 When particular indicator(signal) dashboard page was opened, the date was inherited from the "main page". Not it is fixed, once we click on indicator(signal) to open it's dashboard, the date is going to be set to the start of the latest epiweek.

