### PR TITLE
Dashboard signals update

### DIFF
--- a/src/stores/descriptions.raw.txt
+++ b/src/stores/descriptions.raw.txt
@@ -21,6 +21,39 @@ SignalTooltip: Google search volume of COVID-related symptom searches about comm
  
 Description: Using Google Symptoms Searches, Delphi obtains the average of Google search volumes for searches related to nasal congestion, post nasal drip, rhinorrhea, sinusitis, rhinitis, and common cold in each area. These symptoms have shown positive correlation with reported COVID cases, especially since Omicron was declared a variant of concern by the World Health Organization. Note that the average search volume of these symptoms is not equivalent to the search volume of their union. According to Google, the estimates are not comparable across regions since the values are normalized by population and scaled by region-specific maximum popularity (and for this reason, we omit beehive grids and choropleth maps of this signal on the dashboard).
 ---
+Name: Symptom Searches (Cough, Phlegm, Sputum, Upper respiratory tract infection) on Google 
+Id: google-symptoms
+Signal: s01_smoothed_search
+Unit: scaled search volume
+UnitShort: 
+noMaps: true
+ 
+SignalTooltip: Google search volume of COVID-related symptom searches about Cough, Phlegm, Sputum, Upper respiratory tract infection
+ 
+Description: Using Google Symptoms Searches, Delphi obtains the average of Google search volumes for searches related to cough, phlegm, sputum, and upper respiratory tract infection in each area. These symptoms have shown positive correlation with reported COVID cases. Note that the average search volume of these symptoms is not equivalent to the search volume of their union. According to Google, the estimates are not comparable across regions since the values are normalized by population and scaled by region-specific maximum popularity (and for this reason, we omit beehive grids and choropleth maps of this signal on the dashboard).
+---
+Name: Symptom Searches (Fever, Hyperthermia, Chills, Shivering) on Google 
+Id: google-symptoms
+Signal: s03_smoothed_search
+Unit: scaled search volume
+UnitShort: 
+noMaps: true
+ 
+SignalTooltip: Google search volume of COVID-related symptom searches about Fever, Hyperthermia, Chills, Shivering
+ 
+Description: Using Google Symptoms Searches, Delphi obtains the average of Google search volumes for searches related to fever, hyperthermia, chills, shivering, and low grade fever in each area. These symptoms have shown positive correlation with reported COVID cases. Note that the average search volume of these symptoms is not equivalent to the search volume of their union. According to Google, the estimates are not comparable across regions since the values are normalized by population and scaled by region-specific maximum popularity (and for this reason, we omit beehive grids and choropleth maps of this signal on the dashboard).
+---
+Name: Symptom Searches (Shortness of breath, Wheeze, Croup, Pneumonia, Asthma, Crackles, Bronchitis) on Google 
+Id: google-symptoms
+Signal: s04_smoothed_search
+Unit: scaled search volume
+UnitShort: 
+noMaps: true
+ 
+SignalTooltip: Google search volume of COVID-related symptom searches about Shortness of breath, Wheeze, Croup, Pneumonia, Asthma, Crackles, Bronchitis
+ 
+Description: Using Google Symptoms Searches, Delphi obtains the average of Google search volumes for searches related to shortness of breath, wheeze, croup, pneumonia, asthma, crackles, acute bronchitis, and bronchitis in each area. These symptoms have shown positive correlation with reported COVID cases. Note that the average search volume of these symptoms is not equivalent to the search volume of their union. According to Google, the estimates are not comparable across regions since the values are normalized by population and scaled by region-specific maximum popularity (and for this reason, we omit beehive grids and choropleth maps of this signal on the dashboard).
+---
 Name: COVID-Related Doctor Visits
 Id: doctor-visits
 Signal: smoothed_adj_cli
@@ -32,49 +65,18 @@ SignalTooltip: Percentage of daily doctor visits that are due to COVID-like symp
 
 Description: Delphi receives aggregated statistics from health system partners on COVID-related outpatient doctor visits, derived from ICD codes found in insurance claims. Using this data, we estimate the percentage of daily doctor’s visits in each area that are due to COVID-like illness. Note that these estimates are based only on visits by patients whose data is accessible to our partners.
 ---
-Name: Lab-Confirmed Flu in Doctor Visits
-Id: chng
-Signal: smoothed_adj_outpatient_flu
-Unit: per 100 visits
-
-
-SignalTooltip: Percentage of daily doctor visits that are due to lab-confirmed influenza
-
-
-Description: Delphi receives aggregated statistics from Change Healthcare, Inc. on lab-confirmed influenza outpatient doctor visits, derived from ICD codes found in insurance claims. Using this data, we estimate the percentage of daily doctor’s visits in each area that resulted in a diagnosis of influenza. Note that these estimates are based only on visits by patients whose insurance claims are accessible to Change Healthcare.
----
-Name: COVID Hospital Admissions
-Id: hhs
-Signal: confirmed_admissions_covid_1d_prop_7dav
+Name: COVID Hospital Admissions From Claims
+Id: hospital-admissions
+Signal: smoothed_adj_covid19_from_claims
 ExtendedColorScale: true
-# override with additional county
-Levels: [nation, state, county]
-Overrides:
-  County:
-    Id: hospital-admissions
-    Signal: smoothed_adj_covid19_from_claims
 
 
 
 
-SignalTooltip: Confirmed COVID-19 hospital admissions per 100,000 people
+SignalTooltip: COVID Hospital Admissions From Claims
 
 
-Description: This data shows the number of hospital admissions with lab-confirmed COVID-19 each day. At the state level and above, we show data from the Report on Patient Impact and Hospital Capacity published by the US Department of Health & Human Services (HHS). At the county and metro level, we show data from the Community Profile Report published by the Data Strategy Execution Workgroup. 
----
-Name: Flu Hospital Admissions
-Id: hhs
-Signal: confirmed_admissions_influenza_1d_prop_7dav
-ExtendedColorScale: true
-Levels: [nation, state]
-
-
-
-
-SignalTooltip: Confirmed influenza hospital admissions per 100,000 people
-
-
-Description: This data shows the number of hospital admissions with lab-confirmed influenza each day. We source this data from the Report on Patient Impact and Hospital Capacity published by the US Department of Health & Human Services (HHS). 
+Description: Estimated percentage of new hospital admissions with COVID-associated diagnoses, based on counts of claims from health system partners, smoothed in time using a Gaussian linear smoother, and adjusted to reduce day-of-week effects.
 ---
 Name: COVID Deaths
 Id: nchs-mortality
@@ -85,3 +87,19 @@ SignalTooltip: Newly reported COVID-19 deaths per 100,000 people, based on NCHS 
 
 
 Description: This data shows the number of COVID-19 deaths newly reported each week. The signal is based on COVID-19 death counts compiled and made public by [the National Center for Health Statistics](https://www.cdc.gov/nchs/nvss/vsrr/COVID19/index.htm).
+---
+Name: COVID Emergency Department Visits (Percent of total ED visits)
+Id: nssp
+Signal: pct_ed_visits_covid
+
+SignalTooltip: COVID Emergency Department Visits (Percent of total ED visits)
+
+Description: Percent of ED visits that had a discharge diagnosis code of COVID-19
+---
+Name: Influenza Emergency Department Visits (Percent of total ED visits)
+Id: nssp
+Signal: pct_ed_visits_influenza
+
+SignalTooltip: Influenza Emergency Department Visits (Percent of total ED visits)
+
+Description: Percent of ED visits that had a discharge diagnosis code of influenza

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -112,7 +112,7 @@ export const defaultCasesSensor = derived(sensorList, (sensorList) => {
   return sensorList.find((d) => d.signal === 'smoothed_adj_cli');
 });
 export const defaultHospitalSensor = derived(sensorList, (sensorList) => {
-  return sensorList.find((d) => d.signal === 'confirmed_admissions_covid_1d_prop_7dav');
+  return sensorList.find((d) => d.signal === 'smoothed_adj_covid19_from_claims');
 });
 export const defaultDeathSensor = derived(sensorList, (sensorList) => {
   return sensorList.find((d) => d.signal === 'deaths_covid_incidence_prop');


### PR DESCRIPTION
This brings the COVIDcast dashboard signals up to date by removing inactive signals and adding newer ones...

* CHANGED:
  * `hhs : confirmed_admissions_covid_1d_prop_7dav` --> `hospital-admissions : smoothed_adj_covid19_from_claims`
* REMOVED:
  * `hhs : confirmed_admissions_influenza_1d_prop_7dav`
  * `chng : smoothed_adj_outpatient_flu`
* ADDED:
  * `google-symptoms : s01_smoothed_search`
  * `google-symptoms : s03_smoothed_search`
  * `google-symptoms : s04_smoothed_search`
  * `nssp : pct_ed_visits_covid`
  * `nssp : pct_ed_visits_influenza`

