### PR TITLE
update gh 'actions/cache' away from deprecated version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
         with:
           node-version: 18
       - name: Cache Node.js modules
-        uses: actions/cache@v4.0.1
+        uses: actions/cache@v4
         with:
           path: ~/.npm # npm cache files are stored in `~/.npm` on Linux/macOS
           key: ${{ runner.OS }}-node2-${{ hashFiles('**/package-lock.json') }}

--- a/.github/workflows/release_main.yml
+++ b/.github/workflows/release_main.yml
@@ -47,7 +47,7 @@ jobs:
         with:
           node-version: 18
       - name: Cache Node.js modules
-        uses: actions/cache@v4.0.1
+        uses: actions/cache@v4
         with:
           path: ~/.npm # npm cache files are stored in `~/.npm` on Linux/macOS
           key: ${{ runner.OS }}-node2-${{ hashFiles('**/package-lock.json') }}
@@ -78,7 +78,7 @@ jobs:
         with:
           node-version: 18
       - name: Cache Node.js modules
-        uses: actions/cache@v4.0.1
+        uses: actions/cache@v4
         with:
           path: ~/.npm # npm cache files are stored in `~/.npm` on Linux/macOS
           key: ${{ runner.OS }}-main-node2-${{ hashFiles('**/package-lock.json') }}

--- a/.github/workflows/update_gdocs_data.yml
+++ b/.github/workflows/update_gdocs_data.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           node-version: 18
       - name: Cache Node.js modules
-        uses: actions/cache@v4.0.1
+        uses: actions/cache@v4
         with:
           path: ~/.npm # npm cache files are stored in `~/.npm` on Linux/macOS
           key: ${{ runner.OS }}-node2-${{ hashFiles('**/package-lock.json') }}


### PR DESCRIPTION
The version currently referenced causes actions to fail:
https://github.com/cmu-delphi/www-covidcast/actions/runs/13954044807/job/39081797085#step:1:37

This PR is very similar/analogous to https://github.com/cmu-delphi/delphi-epidata/pull/1603 .