### PR TITLE
Extend indicator status page

### DIFF
--- a/src/components/SensorBadges.svelte
+++ b/src/components/SensorBadges.svelte
@@ -33,10 +33,10 @@
     <span class="uk-badge is-smooth" title="uses a trailing average">smoothed</span>
   {/if}
   {#if meta.is_cumulative}
-    <span class="uk-badge is-cumulative" title="is a cumulative signal">cumulative</span>
+    <span class="uk-badge is-cumulative" title="is a cumulative indicator">cumulative</span>
   {/if}
   {#if meta.is_weighted}
-    <span class="uk-badge is-weighted" title="is a weighted signal">weighted</span>
+    <span class="uk-badge is-weighted" title="is a weighted indicator">weighted</span>
   {/if}
   {#if meta.has_stderr}
     <span class="uk-badge has-stderr" title="includes standard error information">stderr</span>

--- a/src/modes/exportdata/ExportData.svelte
+++ b/src/modes/exportdata/ExportData.svelte
@@ -207,10 +207,10 @@
   <div class="uk-container content-grid">
     <div class="grid-3-11">
       <p>
-        All signals displayed in COVIDcast are freely available for download here. You can also access the latest daily
-        through the
+        All indicators displayed in COVIDcast are freely available for download here. You can also access the latest
+        daily through the
         <a href="https://cmu-delphi.github.io/delphi-epidata/api/covidcast.html">COVIDcast API</a>
-        which also includes numerous other signals.
+        which also includes numerous other indicators.
       </p>
       <section class="uk-margin-top">
         <FancyHeader sub="Data Source" normal>1. Select</FancyHeader>
@@ -228,7 +228,7 @@
                 {/each}
               </select>
             </div>
-            <label><input type="checkbox" bind:checked={showInActive} />Show Inactive Signals</label>
+            <label><input type="checkbox" bind:checked={showInActive} />Show Inactive Indicators</label>
           </div>
         </div>
 
@@ -254,10 +254,10 @@
       </section>
 
       <section class="uk-margin-top">
-        <FancyHeader sub="Signal" normal>2. Select</FancyHeader>
+        <FancyHeader sub="Indicator" normal>2. Select</FancyHeader>
         <p>Pick a signal from this data source.</p>
         <div class="uk-width-1-1@m uk-width-expand@s">
-          <label for="ds" class="uk-form-label">Signals</label>
+          <label for="ds" class="uk-form-label">Indicators</label>
           <div class="uk-form-controls">
             <select id="ds" bind:value={sensorValue} size="8" class="uk-select">
               {#if source}

--- a/src/modes/indicator-status/DataAnomalies.svelte
+++ b/src/modes/indicator-status/DataAnomalies.svelte
@@ -73,7 +73,7 @@
   let details = -1;
 
   function signals(signals) {
-    return signals === '*' ? 'All Signals' : [...signals].join(', ');
+    return signals === '*' ? 'All Indicators' : [...signals].join(', ');
   }
   function regionName(regions) {
     const mapped = regions
@@ -183,7 +183,7 @@
               <p>
                 {r.annotation.explanation}
               </p>
-              <p><strong>Affected Signals:</strong> {signals(r.annotation.signals)}</p>
+              <p><strong>Affected Indicators:</strong> {signals(r.annotation.signals)}</p>
               <p><strong>Affected Regions:</strong> {regionLong(r.annotation.regions)}</p>
             </td>
           </tr>

--- a/src/modes/indicator-status/IndicatorSignalTable.svelte
+++ b/src/modes/indicator-status/IndicatorSignalTable.svelte
@@ -65,7 +65,7 @@
         <td>
           <a href="../indicator-signal?sensor={r.key}" on:click|preventDefault={() => select(r)}>
             {#if source.reference_signal == r.signal}
-              <span class="inline-svg-icon" title="reference signal for this data source" style="padding: 0"
+              <span class="inline-svg-icon" title="reference indicator for this data source" style="padding: 0"
                 >{@html StarIcon}</span
               >
             {/if}

--- a/src/modes/indicator-status/IndicatorSource.svelte
+++ b/src/modes/indicator-status/IndicatorSource.svelte
@@ -86,7 +86,7 @@
       <FancyHeader invert sub="Information">Coverage</FancyHeader>
       {#if referenceSignal}
         <p>
-          Reference Signal: <a
+          Reference Indicator: <a
             href="../indicator-signal?sensor={referenceSignal.key}"
             on:click|preventDefault={() => select(referenceSignal)}
           >

--- a/src/modes/indicator-status/IndicatorStatusOverview.svelte
+++ b/src/modes/indicator-status/IndicatorStatusOverview.svelte
@@ -8,6 +8,11 @@
     currentSensor.set(`${e.detail.source}-${e.detail.reference_signal}`);
     switchToMode(modeByID['indicator-source']);
   }
+
+  function switchToSignal(e) {
+    currentSensor.set(e.detail.key);
+    switchToMode(modeByID['indicator-signal']);
+  }
 </script>
 
 <div class="mobile-root">
@@ -28,8 +33,8 @@
         public health and behavior data, you're in the right place.
       </div>
     </AboutSection>
-    <div class="grid-3-11">
-      <IndicatorStatusTable on:select={switchToDetails} />
+    <div class="grid-2-12">
+      <IndicatorStatusTable on:select={switchToDetails} on:selectSignal={switchToSignal} />
     </div>
   </div>
 </div>

--- a/src/modes/indicator-status/IndicatorStatusTable.svelte
+++ b/src/modes/indicator-status/IndicatorStatusTable.svelte
@@ -43,6 +43,10 @@
     // zero: true,
     // valueDomain: [0, 1]
   });
+
+  $: {
+    console.log('sortedData', sortedData);
+  }
 </script>
 
 <div class="uk-position-relative">
@@ -54,9 +58,11 @@
     prepareRow={(row) => ({
       name: row.name,
       latest_issue: row.latest_issue,
+      typical_reporting_cadence: row.time_type == 'day' ? 1 : 7,
       latest_time_value: row.latest_time_value,
       latest_coverage: row.latest_coverage,
       latest_lag: row.latest_lag_days,
+      latest_report_delay: row.latest_report_delay,
     })}
     advanced={false}
   />
@@ -66,15 +72,19 @@
   <thead>
     <tr>
       <th class="mobile-th">Data Source</th>
-      <th class="mobile-th uk-text-center" colspan="5">Reference Signal</th>
+      <th class="mobile-th uk-text-center" colspan="7">Reference Signal</th>
       <th rowspan="2" />
     </tr>
     <tr>
       <th />
       <th class="mobile-th uk-text-right" title="Date the most recent update was published by Delphi">Latest Issue</th>
+      <th class="mobile-th uk-text-right" title="Date the most recent update was published by Delphi"
+        >Typical Reporting Cadence</th
+      >
       <th class="mobile-th uk-text-right" title="Most recent date for which data is available">Latest Data</th>
-      <th class="mobile-th uk-text-right">Lag to Today</th>
-      <th class="mobile-th uk-text-right" title="Percent of US counties included in latest day of data"
+      <th class="mobile-th uk-text-right" title="Typical Reporting Lag">Typical Reporting Lag</th>
+      <th class="mobile-th uk-text-right" title="Lag to Today">Lag to Today</th>
+      <th class="mobile-th uk-text-center" title="Percent of US counties included in latest day of data"
         >Latest County Coverage</th
       >
       <th class="mobile-th uk-text-right">
@@ -93,10 +103,16 @@
         <SortColumnIndicator label="Latest Issue" {sort} prop="latest_issue" />
       </th>
       <th class="sort-indicator">
+        <SortColumnIndicator label="Typical Reporting Cadence" {sort} prop="typical_reporting_cadence" />
+      </th>
+      <th class="sort-indicator">
         <SortColumnIndicator label="Latest Data" {sort} prop="latest_time_value" />
       </th>
       <th class="sort-indicator">
         <SortColumnIndicator label="Lag" {sort} prop="latest_lag_days" />
+      </th>
+      <th class="sort-indicator">
+        <SortColumnIndicator label="Reporting Delay" {sort} prop="latest_report_delay" />
       </th>
       <th class="sort-indicator">
         <SortColumnIndicator label="Latest Coverage" {sort} prop="latest_coverage" />
@@ -123,11 +139,17 @@
         <td class="uk-text-right uk-text-nowrap">
           {r.ref.isWeeklySignal ? formatWeek(r.latest_issue_week) : formatDateISO(r.latest_issue)}
         </td>
+        <td class="uk-text-center uk-text-nowrap">
+          {r.time_type == 'day' ? 1 : 7}
+        </td>
         <td class="uk-text-right uk-text-nowrap">
           {r.ref.isWeeklySignal ? formatWeek(r.latest_data_week) : formatDateISO(r.latest_data)}
         </td>
         <td class="uk-text-right uk-text-nowrap">
           {r.latest_lag}
+        </td>
+        <td class="uk-text-right uk-text-nowrap">
+          {r.latest_report_delay}
         </td>
         <td class="uk-text-right uk-text-nowrap">
           {formatFraction(r.latest_coverage)}

--- a/src/modes/indicator-status/IndicatorStatusTable.svelte
+++ b/src/modes/indicator-status/IndicatorStatusTable.svelte
@@ -56,7 +56,8 @@
     data={loader.loaded}
     absolutePos
     prepareRow={(row) => ({
-      name: row.name,
+      original_data_provider: row.original_data_provider,
+      reference_indicator_name: row.reference_indicator_name,
       latest_issue: row.latest_issue,
       typical_reporting_cadence: row.time_type == 'day' ? 1 : 7,
       latest_time_value: row.latest_time_value,
@@ -73,11 +74,13 @@
 <table class="mobile-table" class:loading>
   <thead>
     <tr>
-      <th class="mobile-th">Data Source</th>
-      <th class="mobile-th uk-text-center" colspan="9">Reference Indicator</th>
+      <th class="mobile-th">Original Data Provider</th>
+      <th class="mobile-th">Reference Indicator</th>
+      <th class="mobile-th uk-text-center" colspan="8">Status</th>
       <th rowspan="2" />
     </tr>
     <tr>
+      <th />
       <th />
       <th class="mobile-th uk-text-right" title="Date the most recent update was published by Delphi">Latest Issue</th>
       <th class="mobile-th uk-text-center" title="Date the most recent update was published by Delphi"
@@ -101,7 +104,10 @@
     </tr>
     <tr>
       <th class="sort-indicator uk-text-center">
-        <SortColumnIndicator label="Name" {sort} prop="name" />
+        <SortColumnIndicator label="Original Data Provider" {sort} prop="original_data_provider" />
+      </th>
+      <th class="sort-indicator">
+        <SortColumnIndicator label="Reference Indicator" {sort} prop="reference_indicator_name" />
       </th>
       <th class="sort-indicator">
         <SortColumnIndicator label="Latest Issue" {sort} prop="latest_issue" />
@@ -137,7 +143,7 @@
         <td>
           <a
             href="../indicator-source?sensor={r.source}-{r.reference_signal}"
-            on:click|preventDefault={() => dispatch('select', r)}>{r.name}</a
+            on:click|preventDefault={() => dispatch('select', r)}>{r.original_data_provider}</a
           >
           <div
             class="source"
@@ -145,6 +151,12 @@
           >
             API data_source: {r.source}
           </div>
+        </td>
+        <td>
+          <a
+            href="../indicator-signal?sensor={r.ref.key}"
+            on:click|preventDefault={() => dispatch('selectSignal', r.ref)}>{r.ref.name}</a
+          >
         </td>
         <td class="uk-text-right uk-text-nowrap">
           {r.ref.isWeeklySignal ? formatWeek(r.latest_issue_week) : formatDateISO(r.latest_issue)}

--- a/src/modes/indicator-status/IndicatorStatusTable.svelte
+++ b/src/modes/indicator-status/IndicatorStatusTable.svelte
@@ -43,10 +43,6 @@
     // zero: true,
     // valueDomain: [0, 1]
   });
-
-  $: {
-    console.log('sortedData', sortedData);
-  }
 </script>
 
 <div class="uk-position-relative">

--- a/src/modes/indicator-status/IndicatorStatusTable.svelte
+++ b/src/modes/indicator-status/IndicatorStatusTable.svelte
@@ -74,7 +74,7 @@
   <thead>
     <tr>
       <th class="mobile-th">Data Source</th>
-      <th class="mobile-th uk-text-center" colspan="9">Reference Signal</th>
+      <th class="mobile-th uk-text-center" colspan="9">Reference Indicator</th>
       <th rowspan="2" />
     </tr>
     <tr>

--- a/src/modes/indicator-status/IndicatorStatusTable.svelte
+++ b/src/modes/indicator-status/IndicatorStatusTable.svelte
@@ -80,14 +80,14 @@
     <tr>
       <th />
       <th class="mobile-th uk-text-right" title="Date the most recent update was published by Delphi">Latest Issue</th>
-      <th class="mobile-th uk-text-right" title="Date the most recent update was published by Delphi"
+      <th class="mobile-th uk-text-center" title="Date the most recent update was published by Delphi"
         >Typical Reporting Cadence</th
       >
       <th class="mobile-th uk-text-right" title="Most recent date for which data is available">Latest Data</th>
-      <th class="mobile-th uk-text-right" title="Typical Reporting Lag">Typical Reporting Lag</th>
-      <th class="mobile-th uk-text-right" title="Lag to Today">Lag to Today</th>
-      <th class="mobile-th uk-text-right" title="Reporting Delay Index">Reporting Delay Index</th>
-      <th class="mobile-th uk-text-right" title="Data Staleness Index">Data Staleness Index</th>
+      <th class="mobile-th uk-text-center" title="Typical Reporting Lag">Typical Reporting Lag</th>
+      <th class="mobile-th uk-text-center" title="Lag to Today">Lag to Today</th>
+      <th class="mobile-th uk-text-center" title="Reporting Delay Index">Reporting Delay Index</th>
+      <th class="mobile-th uk-text-center" title="Data Staleness Index">Data Staleness Index</th>
       <th class="mobile-th uk-text-center" title="Percent of US counties included in latest day of data"
         >Latest County Coverage</th
       >
@@ -161,7 +161,7 @@
         <td class="uk-text-right uk-text-nowrap">
           {r.latest_report_delay}
         </td>
-        <td class="uk-text-right uk-text-nowrap">
+        <td class="uk-text-center uk-text-nowrap">
           {formatValue(r.reporting_delay_index)}
         </td>
         <td class="uk-text-center uk-text-nowrap">

--- a/src/modes/indicator-status/IndicatorStatusTable.svelte
+++ b/src/modes/indicator-status/IndicatorStatusTable.svelte
@@ -1,7 +1,7 @@
 <script>
   import SortColumnIndicator, { SortHelper } from '../../components/SortColumnIndicator.svelte';
   import FancyHeader from '../../components/FancyHeader.svelte';
-  import { formatDateISO, formatDateShortNumbers, formatFraction, formatWeek } from '../../formats';
+  import { formatDateISO, formatDateShortNumbers, formatFraction, formatWeek, formatValue } from '../../formats';
   import DownloadMenu from '../../components/DownloadMenu.svelte';
   import Vega from '../../components/vega/Vega.svelte';
   import { generateSparkLine } from '../../specs/lineSpec';
@@ -63,6 +63,8 @@
       latest_coverage: row.latest_coverage,
       latest_lag: row.latest_lag_days,
       latest_report_delay: row.latest_report_delay,
+      reporting_delay_index: row.reporting_delay_index,
+      data_staleness_index: row.data_staleness_index,
     })}
     advanced={false}
   />
@@ -72,7 +74,7 @@
   <thead>
     <tr>
       <th class="mobile-th">Data Source</th>
-      <th class="mobile-th uk-text-center" colspan="7">Reference Signal</th>
+      <th class="mobile-th uk-text-center" colspan="9">Reference Signal</th>
       <th rowspan="2" />
     </tr>
     <tr>
@@ -84,6 +86,8 @@
       <th class="mobile-th uk-text-right" title="Most recent date for which data is available">Latest Data</th>
       <th class="mobile-th uk-text-right" title="Typical Reporting Lag">Typical Reporting Lag</th>
       <th class="mobile-th uk-text-right" title="Lag to Today">Lag to Today</th>
+      <th class="mobile-th uk-text-right" title="Reporting Delay Index">Reporting Delay Index</th>
+      <th class="mobile-th uk-text-right" title="Data Staleness Index">Data Staleness Index</th>
       <th class="mobile-th uk-text-center" title="Percent of US counties included in latest day of data"
         >Latest County Coverage</th
       >
@@ -113,6 +117,12 @@
       </th>
       <th class="sort-indicator">
         <SortColumnIndicator label="Reporting Delay" {sort} prop="latest_report_delay" />
+      </th>
+      <th class="sort-indicator">
+        <SortColumnIndicator label="Delay Index" {sort} prop="reporting_delay_index" />
+      </th>
+      <th class="sort-indicator">
+        <SortColumnIndicator label="Staleness Index" {sort} prop="data_staleness_index" />
       </th>
       <th class="sort-indicator">
         <SortColumnIndicator label="Latest Coverage" {sort} prop="latest_coverage" />
@@ -150,6 +160,12 @@
         </td>
         <td class="uk-text-right uk-text-nowrap">
           {r.latest_report_delay}
+        </td>
+        <td class="uk-text-right uk-text-nowrap">
+          {formatValue(r.reporting_delay_index)}
+        </td>
+        <td class="uk-text-center uk-text-nowrap">
+          {formatValue(r.data_staleness_index)}
         </td>
         <td class="uk-text-right uk-text-nowrap">
           {formatFraction(r.latest_coverage)}

--- a/src/modes/indicator-status/IndicatorStatusTable.svelte
+++ b/src/modes/indicator-status/IndicatorStatusTable.svelte
@@ -83,7 +83,7 @@
       <th />
       <th />
       <th class="mobile-th uk-text-right" title="Date the most recent update was published by Delphi">Latest Issue</th>
-      <th class="mobile-th uk-text-center" title="Date the most recent update was published by Delphi"
+      <th class="mobile-th uk-text-center" title="How often updates are published by Delphi"
         >Typical Reporting Cadence</th
       >
       <th class="mobile-th uk-text-right" title="Most recent date for which data is available">Latest Data</th>

--- a/src/modes/indicator-status/data.ts
+++ b/src/modes/indicator-status/data.ts
@@ -23,6 +23,7 @@ export interface SourceData extends SensorSource {
   latest_data?: Date | null;
   latest_data_week?: EpiWeek | null;
   latest_lag: string;
+  latest_report_delay: string;
   latest_coverage?: number | null;
   coverages: ParsedCoverageRow[];
 }
@@ -43,6 +44,15 @@ export function toLagToToday(meta?: EpiDataMetaParsedInfo | null): string {
   const nowWeek = EpiWeek.thisWeek();
   const range = weekRange(meta.maxWeek, nowWeek).length;
   return `${range} week${range !== 1 ? 's' : ''}`;
+}
+
+export function toReportDelay(meta?: EpiDataMetaParsedInfo | null): string {
+  if (!meta || !meta.maxIssue) {
+    return '?';
+  }
+  const now = new Date();
+  const range = timeDay.count(meta.maxIssue, now);
+  return `${range} day${range !== 1 ? 's' : ''}`;
 }
 
 export function toLagToTodayDays(meta?: EpiDataMetaParsedInfo | null): number {
@@ -76,6 +86,8 @@ function toInitialData(sources: SensorSource[], manager: MetaDataManager): Sourc
       latest_data_week: meta?.maxWeek,
       latest_lag: toLagToToday(meta),
       latest_lag_days: toLagToTodayDays(meta),
+      latest_report_delay: toReportDelay(meta),
+      time_type: meta?.time_type,
       latest_coverage: null,
       coverages: [],
     };

--- a/src/modes/indicator-status/data.ts
+++ b/src/modes/indicator-status/data.ts
@@ -18,6 +18,7 @@ import { EpiWeek, weekRange } from '../../data/EpiWeek';
 
 export interface SourceData extends SensorSource {
   ref: Sensor;
+  reference_indicator_name: string;
   latest_issue?: Date | null;
   latest_issue_week?: EpiWeek | null;
   latest_data?: Date | null;
@@ -104,6 +105,7 @@ function toInitialData(sources: SensorSource[], manager: MetaDataManager): Sourc
     return {
       ...source,
       ref,
+      reference_indicator_name: ref.name,
       latest_issue: meta?.maxIssue,
       latest_issue_week: meta?.maxIssueWeek,
       latest_data: meta?.maxTime,

--- a/src/modes/indicator-status/data.ts
+++ b/src/modes/indicator-status/data.ts
@@ -24,6 +24,8 @@ export interface SourceData extends SensorSource {
   latest_data_week?: EpiWeek | null;
   latest_lag: string;
   latest_report_delay: string;
+  reporting_delay_index: number;
+  data_staleness_index: number;
   latest_coverage?: number | null;
   coverages: ParsedCoverageRow[];
 }
@@ -53,6 +55,28 @@ export function toReportDelay(meta?: EpiDataMetaParsedInfo | null): string {
   const now = new Date();
   const range = timeDay.count(meta.maxIssue, now);
   return `${range} day${range !== 1 ? 's' : ''}`;
+}
+
+export function toReportingDelayIndex(meta?: EpiDataMetaParsedInfo | null): number {
+  if (!meta || !meta.maxIssue) {
+    return Number.NaN;
+  }
+  const now = new Date();
+  const range = timeDay.count(meta.maxIssue, now);
+  const cadence = meta.time_type === 'day' ? 1 : 7;
+  return range / cadence;
+}
+
+export function toDataStalenessIndex(meta?: EpiDataMetaParsedInfo | null): number {
+  if (!meta || !meta.maxIssue || !meta.maxTime) {
+    return Number.NaN;
+  }
+  const now = new Date();
+  const daysSinceLatestData = timeDay.count(meta.maxTime, now);
+  // Estimate typical reporting lag as the difference between the latest issue and the latest data
+  const typicalReportingLag = Math.max(1, timeDay.count(meta.maxTime, meta.maxIssue));
+
+  return daysSinceLatestData / typicalReportingLag;
 }
 
 export function toLagToTodayDays(meta?: EpiDataMetaParsedInfo | null): number {
@@ -87,6 +111,8 @@ function toInitialData(sources: SensorSource[], manager: MetaDataManager): Sourc
       latest_lag: toLagToToday(meta),
       latest_lag_days: toLagToTodayDays(meta),
       latest_report_delay: toReportDelay(meta),
+      reporting_delay_index: toReportingDelayIndex(meta),
+      data_staleness_index: toDataStalenessIndex(meta),
       time_type: meta?.time_type,
       latest_coverage: null,
       coverages: [],


### PR DESCRIPTION
**Prerequisites**:

- [x] Unless it is a hotfix it should be merged against the `dev` branch
- [x] Branch is up-to-date with the branch to be merged with, i.e. `dev`
- [x] Build is successful
- [x] Code is cleaned up and formatted

### Summary

  - Add a "Typical reporting cadence" column (available in the spreadsheets), to put the "Latest issue" column in contexts
  - Add a "Typical reporting lag" column (available in the spreadsheets), to put the "Latest data " column in contexts
  - Create a "reporting delay" index (days since last report / typical reporting cadence), and "data staleness index" (days since latest data / typical reporting lag), and highlight rows that exceed some threshold of either.
  - Allow the table to be sorted by the various columns, or, failing that, sort in in order of one of the above indices.
<img width="901" height="631" alt="image" src="https://github.com/user-attachments/assets/3c24debf-fda6-4d92-a539-b2a96d663bfc" />
